### PR TITLE
Switches from Webclient to HttpClient

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,12 +13,12 @@ credential creation and requests signing.
     {
         class Program
         {
-            static void Main(string[] args)
+            static async Task Main(string[] args)
             {
                 // Instantiate. Visit https://api.ovh.com/createToken/index.cgi?GET=/me
                 // to get your credentials
                 Client client = new Client("ovh-eu", "<application_key>", "<application_secret>", "<consumer_key>");
-                PartialMe me = client.GetAsync<PartialMe>("/me").Result;
+                PartialMe me = await client.GetAsync<PartialMe>("/me");
 
                 // Print nice welcome message
                 Console.WriteLine(String.Format("Hello {0}!", me.firstname));
@@ -125,7 +125,7 @@ customer's informations:
     {
         class Program
         {
-            static void Main(string[] args)
+            static async Task Main(string[] args)
             {
                 Client client = new Client();
                 CredentialRequest requestPayload = new CredentialRequest(
@@ -144,7 +144,7 @@ customer's informations:
                 Console.ReadLine();
 
                 client.ConsumerKey = credentialRequestResult.ConsumerKey;
-                PartialMe me = client.GetAsync<PartialMe>("/me").Result;
+                PartialMe me = await client.GetAsync<PartialMe>("/me");
 
                 Console.WriteLine(
                     String.Format("Welcome, {0}", me.firstname));
@@ -244,13 +244,13 @@ This example assumes an existing Configuration_ with valid ``application_key``,
     {
         class Program
         {
-            static void Main(string[] args)
+            static async Task Main(string[] args)
             {
                 Client client = new Client();
-                var billIds = client.GetAsync<List<string>>("/me/bill").Result;
+                var billIds = await client.GetAsync<List<string>>("/me/bill");
                 foreach (var billId in billIds)
                 {
-                    PartialOvhBill details = client.GetAsync<PartialOvhBill>("/me/bill/" + billId).Result;
+                    PartialOvhBill details = await client.GetAsync<PartialOvhBill>("/me/bill/" + billId);
                     Console.WriteLine(
                         String.Format("{0} ({1}): {2} --> {3}",
                             billId, details.date, details.priceWithTax.text, details.pdfUrl));
@@ -296,18 +296,18 @@ This example assumes an existing Configuration_ with valid ``application_key``,
     {
         class Program
         {
-            static void Main(string[] args)
+            static async Task Main(string[] args)
             {
                 Client client = new Client();
 
-                var serverIds = client.GetAsync<List<string>>("/dedicated/server/").Result;
+                var serverIds = await client.GetAsync<List<string>>("/dedicated/server/");
                 foreach (var serverId in serverIds)
                 {
                     string serverUrl = "/dedicated/server/" + serverId;
-                    var details = client.GetAsync<PartialDedicatedServer>(serverUrl).Result;
+                    var details = await client.GetAsync<PartialDedicatedServer>(serverUrl);
                     if (details.datacenter == "sbg1")
                     {
-                        client.PutAsync(serverUrl + "/burst", "{\"status\":\"active\"}").Result;
+                        await client.PutAsync(serverUrl + "/burst", "{\"status\":\"active\"}");
                         Console.WriteLine("Burst enabled on server " + serverId);
                     }
                 }
@@ -345,19 +345,19 @@ This example assumes an existing Configuration_ with valid ``application_key``,
     {
         class Program
         {
-            static void Main(string[] args)
+            static async Task Main(string[] args)
             {
                 Client client = new Client();
 
                 QueryStringParams qsp = new QueryStringParams();
                 qsp.Add("status", "validated");
 
-                var credentialIds = client.GetAsync<List<string>>("/me/api/credential", qsp).Result;
+                var credentialIds = await client.GetAsync<List<string>>("/me/api/credential", qsp);
                 foreach (var credentialId in credentialIds)
                 {
                     string credentialUrl = "/me/api/credential/" + credentialId;
-                    var credential = client.GetAsync<PartialCredential>(credentialUrl).Result;
-                    var application = client.GetAsync<PartialApplication>(credentialUrl + "/application").Result;
+                    var credential = await client.GetAsync<PartialCredential>(credentialUrl);
+                    var application = await client.GetAsync<PartialApplication>(credentialUrl + "/application");
 
                     StringBuilder sb = new StringBuilder();
                     sb.Append(credentialId).Append(" ").Append(application.status)

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ credential creation and requests signing.
                 // Instantiate. Visit https://api.ovh.com/createToken/index.cgi?GET=/me
                 // to get your credentials
                 Client client = new Client("ovh-eu", "<application_key>", "<application_secret>", "<consumer_key>");
-                PartialMe me = client.Get<PartialMe>("/me");
+                PartialMe me = client.GetAsync<PartialMe>("/me").Result;
 
                 // Print nice welcome message
                 Console.WriteLine(String.Format("Hello {0}!", me.firstname));
@@ -144,7 +144,7 @@ customer's informations:
                 Console.ReadLine();
 
                 client.ConsumerKey = credentialRequestResult.ConsumerKey;
-                PartialMe me = client.Get<PartialMe>("/me");
+                PartialMe me = client.GetAsync<PartialMe>("/me").Result;
 
                 Console.WriteLine(
                     String.Format("Welcome, {0}", me.firstname));
@@ -209,10 +209,10 @@ OVH to an arbitrary destination e-mail using API call
                 payload.Add("to", destination);
                 payload.Add("localCopy", false);
 
-                client.Post(
+                client.PostAsync(
                     String.Format("/email/domain/{0}/redirection", domain),
                     JsonConvert.SerializeObject(payload)
-                );
+                ).Wait();
 
                 Console.WriteLine(
                     String.Format("Installed new mail redirection from {0} to {1}",
@@ -247,10 +247,10 @@ This example assumes an existing Configuration_ with valid ``application_key``,
             static void Main(string[] args)
             {
                 Client client = new Client();
-                var billIds = client.Get<List<string>>("/me/bill");
+                var billIds = client.GetAsync<List<string>>("/me/bill").Result;
                 foreach (var billId in billIds)
                 {
-                    PartialOvhBill details = client.Get<PartialOvhBill>("/me/bill/" + billId);
+                    PartialOvhBill details = client.GetAsync<PartialOvhBill>("/me/bill/" + billId).Result;
                     Console.WriteLine(
                         String.Format("{0} ({1}): {2} --> {3}",
                             billId, details.date, details.priceWithTax.text, details.pdfUrl));
@@ -300,14 +300,14 @@ This example assumes an existing Configuration_ with valid ``application_key``,
             {
                 Client client = new Client();
 
-                var serverIds = client.Get<List<string>>("/dedicated/server/");
+                var serverIds = client.GetAsync<List<string>>("/dedicated/server/").Result;
                 foreach (var serverId in serverIds)
                 {
                     string serverUrl = "/dedicated/server/" + serverId;
-                    var details = client.Get<PartialDedicatedServer>(serverUrl);
+                    var details = client.GetAsync<PartialDedicatedServer>(serverUrl).Result;
                     if (details.datacenter == "sbg1")
                     {
-                        client.Put(serverUrl + "/burst", "{\"status\":\"active\"}");
+                        client.PutAsync(serverUrl + "/burst", "{\"status\":\"active\"}").Result;
                         Console.WriteLine("Burst enabled on server " + serverId);
                     }
                 }
@@ -352,12 +352,12 @@ This example assumes an existing Configuration_ with valid ``application_key``,
                 QueryStringParams qsp = new QueryStringParams();
                 qsp.Add("status", "validated");
 
-                var credentialIds = client.Get<List<string>>("/me/api/credential", qsp);
+                var credentialIds = client.GetAsync<List<string>>("/me/api/credential", qsp).Result;
                 foreach (var credentialId in credentialIds)
                 {
                     string credentialUrl = "/me/api/credential/" + credentialId;
-                    var credential = client.Get<PartialCredential>(credentialUrl);
-                    var application = client.Get<PartialApplication>(credentialUrl + "/application");
+                    var credential = client.GetAsync<PartialCredential>(credentialUrl).Result;
+                    var application = client.GetAsync<PartialApplication>(credentialUrl + "/application").Result;
 
                     StringBuilder sb = new StringBuilder();
                     sb.Append(credentialId).Append(" ").Append(application.status)

--- a/csharp-ovh/Client/Client.Delete.cs
+++ b/csharp-ovh/Client/Client.Delete.cs
@@ -11,7 +11,7 @@ namespace Ovh.Api
         /// <param name="target">API method to call</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>Raw API response</returns>
-        [Obsolete("This method just calls the async version and applies '.Result' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
+        [Obsolete("This method just calls the async version and applies 'GetAwaiter().GetResult()' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
         public string Delete(string target, bool needAuth = true)
         {
             return Call("DELETE", target, null, needAuth);
@@ -24,7 +24,7 @@ namespace Ovh.Api
         /// <param name="target">API method to call</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>API response deserialized to T by JSON.Net</returns>
-        [Obsolete("This method just calls the async version and applies '.Result' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
+        [Obsolete("This method just calls the async version and applies 'GetAwaiter().GetResult()' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
         public T Delete<T>(string target, bool needAuth = true)
         {
             return Call<T>("DELETE", target, null, needAuth);

--- a/csharp-ovh/Client/Client.Delete.cs
+++ b/csharp-ovh/Client/Client.Delete.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 
 namespace Ovh.Api
@@ -10,6 +11,7 @@ namespace Ovh.Api
         /// <param name="target">API method to call</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>Raw API response</returns>
+        [Obsolete("This method just calls the async version and applies '.Result' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
         public string Delete(string target, bool needAuth = true)
         {
             return Call("DELETE", target, null, needAuth);
@@ -22,6 +24,7 @@ namespace Ovh.Api
         /// <param name="target">API method to call</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>API response deserialized to T by JSON.Net</returns>
+        [Obsolete("This method just calls the async version and applies '.Result' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
         public T Delete<T>(string target, bool needAuth = true)
         {
             return Call<T>("DELETE", target, null, needAuth);

--- a/csharp-ovh/Client/Client.Get.cs
+++ b/csharp-ovh/Client/Client.Get.cs
@@ -1,7 +1,6 @@
+using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Threading.Tasks;
-using Ovh.Api;
 
 namespace Ovh.Api
 {
@@ -14,6 +13,7 @@ namespace Ovh.Api
         /// <param name="kwargs">Arguments to append to URL</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>Raw API response</returns>
+        [Obsolete("This method just calls the async version and applies '.Result' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
         public string Get(string target, QueryStringParams kwargs = null, bool needAuth = true)
         {
             target += kwargs?.ToString();
@@ -27,6 +27,7 @@ namespace Ovh.Api
         /// <param name="kwargs">Arguments to append to URL</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>Raw API response</returns>
+        [Obsolete("This method just calls the async version and applies '.Result' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
         public string GetBatch(string target, QueryStringParams kwargs = null, bool needAuth = true)
         {
             target += kwargs?.ToString();
@@ -42,6 +43,7 @@ namespace Ovh.Api
         /// <param name="kwargs">Arguments to append to URL</param>
         /// <param name="isBatch">If true, this will query multiple resources in one call</param>
         /// <returns>API response deserialized to List<T> by JSON.Net</returns>
+        [Obsolete("This method just calls the async version and applies '.Result' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
         public List<T> GetBatch<T>(string target, QueryStringParams kwargs = null, bool needAuth = true)
         {
             target += kwargs?.ToString();
@@ -56,6 +58,7 @@ namespace Ovh.Api
         /// <param name="kwargs">Arguments to append to URL</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>API response deserialized to T by JSON.Net</returns>
+        [Obsolete("This method just calls the async version and applies '.Result' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
         public T Get<T>(string target, QueryStringParams kwargs = null, bool needAuth = true)
         {
             target += kwargs?.ToString();

--- a/csharp-ovh/Client/Client.Get.cs
+++ b/csharp-ovh/Client/Client.Get.cs
@@ -13,7 +13,7 @@ namespace Ovh.Api
         /// <param name="kwargs">Arguments to append to URL</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>Raw API response</returns>
-        [Obsolete("This method just calls the async version and applies '.Result' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
+        [Obsolete("This method just calls the async version and applies 'GetAwaiter().GetResult()' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
         public string Get(string target, QueryStringParams kwargs = null, bool needAuth = true)
         {
             target += kwargs?.ToString();
@@ -27,7 +27,7 @@ namespace Ovh.Api
         /// <param name="kwargs">Arguments to append to URL</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>Raw API response</returns>
-        [Obsolete("This method just calls the async version and applies '.Result' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
+        [Obsolete("This method just calls the async version and applies 'GetAwaiter().GetResult()' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
         public string GetBatch(string target, QueryStringParams kwargs = null, bool needAuth = true)
         {
             target += kwargs?.ToString();
@@ -43,7 +43,7 @@ namespace Ovh.Api
         /// <param name="kwargs">Arguments to append to URL</param>
         /// <param name="isBatch">If true, this will query multiple resources in one call</param>
         /// <returns>API response deserialized to List<T> by JSON.Net</returns>
-        [Obsolete("This method just calls the async version and applies '.Result' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
+        [Obsolete("This method just calls the async version and applies 'GetAwaiter().GetResult()' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
         public List<T> GetBatch<T>(string target, QueryStringParams kwargs = null, bool needAuth = true)
         {
             target += kwargs?.ToString();
@@ -58,7 +58,7 @@ namespace Ovh.Api
         /// <param name="kwargs">Arguments to append to URL</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>API response deserialized to T by JSON.Net</returns>
-        [Obsolete("This method just calls the async version and applies '.Result' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
+        [Obsolete("This method just calls the async version and applies 'GetAwaiter().GetResult()' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
         public T Get<T>(string target, QueryStringParams kwargs = null, bool needAuth = true)
         {
             target += kwargs?.ToString();

--- a/csharp-ovh/Client/Client.Iterate.cs
+++ b/csharp-ovh/Client/Client.Iterate.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace Ovh.Api

--- a/csharp-ovh/Client/Client.Post.cs
+++ b/csharp-ovh/Client/Client.Post.cs
@@ -12,7 +12,7 @@ namespace Ovh.Api
         /// <param name="data">Json data to send as body</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>Raw API response</returns>
-        [Obsolete("This method just calls the async version and applies '.Result' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
+        [Obsolete("This method just calls the async version and applies 'GetAwaiter().GetResult()' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
         public string Post(string target, string data, bool needAuth = true)
         {
             return Call("POST", target, data, needAuth);
@@ -26,7 +26,7 @@ namespace Ovh.Api
         /// <param name="data">Json data to send as body</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>API response deserialized to T by JSON.Net</returns>
-        [Obsolete("This method just calls the async version and applies '.Result' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
+        [Obsolete("This method just calls the async version and applies 'GetAwaiter().GetResult()' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
         public T Post<T>(string target, string data, bool needAuth = true)
         {
             return Call<T>("POST", target, data, needAuth);
@@ -41,7 +41,7 @@ namespace Ovh.Api
         /// <param name="data">Json data to send as body</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>API response deserialized to T by JSON.Net with Strongly typed object as input</returns>
-        [Obsolete("This method just calls the async version and applies '.Result' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
+        [Obsolete("This method just calls the async version and applies 'GetAwaiter().GetResult()' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
         public T Post<T, Y>(string target, Y data, bool needAuth = true)
             where Y : class
         {

--- a/csharp-ovh/Client/Client.Post.cs
+++ b/csharp-ovh/Client/Client.Post.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 
 namespace Ovh.Api
@@ -11,6 +12,7 @@ namespace Ovh.Api
         /// <param name="data">Json data to send as body</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>Raw API response</returns>
+        [Obsolete("This method just calls the async version and applies '.Result' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
         public string Post(string target, string data, bool needAuth = true)
         {
             return Call("POST", target, data, needAuth);
@@ -24,6 +26,7 @@ namespace Ovh.Api
         /// <param name="data">Json data to send as body</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>API response deserialized to T by JSON.Net</returns>
+        [Obsolete("This method just calls the async version and applies '.Result' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
         public T Post<T>(string target, string data, bool needAuth = true)
         {
             return Call<T>("POST", target, data, needAuth);
@@ -38,6 +41,7 @@ namespace Ovh.Api
         /// <param name="data">Json data to send as body</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>API response deserialized to T by JSON.Net with Strongly typed object as input</returns>
+        [Obsolete("This method just calls the async version and applies '.Result' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
         public T Post<T, Y>(string target, Y data, bool needAuth = true)
             where Y : class
         {

--- a/csharp-ovh/Client/Client.Put.cs
+++ b/csharp-ovh/Client/Client.Put.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 
 namespace Ovh.Api
@@ -11,6 +12,7 @@ namespace Ovh.Api
         /// <param name="data">Json data to send as body</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>Raw API response</returns>
+        [Obsolete("This method just calls the async version and applies '.Result' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
         public string Put(string target, string data, bool needAuth = true)
         {
             return Call("PUT", target, data, needAuth);
@@ -24,6 +26,7 @@ namespace Ovh.Api
         /// <param name="data">Json data to send as body</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>API response deserialized to T by JSON.Net</returns>
+        [Obsolete("This method just calls the async version and applies '.Result' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
         public T Put<T>(string target, string data, bool needAuth = true)
         {
             return Call<T>("PUT", target, data, needAuth);
@@ -38,6 +41,7 @@ namespace Ovh.Api
         /// <param name="data">Json data to send as body</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>API response deserialized to T by JSON.Net with Strongly typed object as input</returns>
+        [Obsolete("This method just calls the async version and applies '.Result' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
         public T Put<T, Y>(string target, Y data, bool needAuth = true)
             where Y : class
         {
@@ -84,5 +88,5 @@ namespace Ovh.Api
             return CallAsync<T, Y>("PUT", target, data, needAuth);
         }
     }
-    
+
 }

--- a/csharp-ovh/Client/Client.Put.cs
+++ b/csharp-ovh/Client/Client.Put.cs
@@ -12,7 +12,7 @@ namespace Ovh.Api
         /// <param name="data">Json data to send as body</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>Raw API response</returns>
-        [Obsolete("This method just calls the async version and applies '.Result' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
+        [Obsolete("This method just calls the async version and applies 'GetAwaiter().GetResult()' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
         public string Put(string target, string data, bool needAuth = true)
         {
             return Call("PUT", target, data, needAuth);
@@ -26,7 +26,7 @@ namespace Ovh.Api
         /// <param name="data">Json data to send as body</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>API response deserialized to T by JSON.Net</returns>
-        [Obsolete("This method just calls the async version and applies '.Result' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
+        [Obsolete("This method just calls the async version and applies 'GetAwaiter().GetResult()' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
         public T Put<T>(string target, string data, bool needAuth = true)
         {
             return Call<T>("PUT", target, data, needAuth);
@@ -41,7 +41,7 @@ namespace Ovh.Api
         /// <param name="data">Json data to send as body</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>API response deserialized to T by JSON.Net with Strongly typed object as input</returns>
-        [Obsolete("This method just calls the async version and applies '.Result' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
+        [Obsolete("This method just calls the async version and applies 'GetAwaiter().GetResult()' to it. You should not rely on this as it can cause deadlocks. This method will be removed in 4.0.0, switch to the async one.")]
         public T Put<T, Y>(string target, Y data, bool needAuth = true)
             where Y : class
         {

--- a/csharp-ovh/Testing/ITimeProvider.cs
+++ b/csharp-ovh/Testing/ITimeProvider.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Ovh.Api.Testing
+{
+    public interface ITimeProvider
+    {
+        DateTimeOffset Now { get; }
+        DateTimeOffset UtcNow { get; }
+    }
+}

--- a/csharp-ovh/Testing/TimeProvider.cs
+++ b/csharp-ovh/Testing/TimeProvider.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Ovh.Api.Testing
+{
+    public class TimeProvider : ITimeProvider
+    {
+        DateTimeOffset ITimeProvider.Now => DateTimeOffset.Now;
+        DateTimeOffset ITimeProvider.UtcNow => DateTimeOffset.UtcNow;
+    }
+}

--- a/csharp-ovh/csharp-ovh.csproj
+++ b/csharp-ovh/csharp-ovh.csproj
@@ -17,4 +17,10 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 
+  <ItemGroup>
+  <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+    <_Parameter1>test</_Parameter1>
+  </AssemblyAttribute>
+</ItemGroup>
+
 </Project>

--- a/csharp-ovh/csharp-ovh.csproj
+++ b/csharp-ovh/csharp-ovh.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>csharp-ovh</AssemblyName>
-    <Version>3.2</Version>
+    <Version>3.3.0</Version>
     <Authors>Luke Marlin</Authors>
     <Company>OVH</Company>
     <Description>Csharp-OVH Class Library</Description>

--- a/test/ClientFactory.cs
+++ b/test/ClientFactory.cs
@@ -11,9 +11,9 @@ namespace Ovh.Test
         {
             if(withConsumerKey)
             {
-                return new Client(Constants.ENDPOINT, Constants.APPLICATION_KEY, Constants.APPLICATION_SECRET, Constants.CONSUMER_KEY, httpClient: new HttpClient(handler));
+                return new Client(new HttpClient(handler), Constants.ENDPOINT, Constants.APPLICATION_KEY, Constants.APPLICATION_SECRET, Constants.CONSUMER_KEY);
             }
-            return new Client(Constants.ENDPOINT, Constants.APPLICATION_KEY, Constants.APPLICATION_SECRET, httpClient: new HttpClient(handler));
+            return new Client(new HttpClient(handler), Constants.ENDPOINT, Constants.APPLICATION_KEY, Constants.APPLICATION_SECRET);
         }
 
     }

--- a/test/ClientFactory.cs
+++ b/test/ClientFactory.cs
@@ -1,0 +1,21 @@
+using System.Net.Http;
+using Ovh.Api;
+
+namespace Ovh.Test
+{
+    public static class ClientFactory
+    {
+
+
+        public static Client GetClient(FakeHttpMessageHandler handler, bool withConsumerKey = true)
+        {
+            if(withConsumerKey)
+            {
+                return new Client(Constants.ENDPOINT, Constants.APPLICATION_KEY, Constants.APPLICATION_SECRET, Constants.CONSUMER_KEY, httpClient: new HttpClient(handler));
+            }
+            return new Client(Constants.ENDPOINT, Constants.APPLICATION_KEY, Constants.APPLICATION_SECRET, httpClient: new HttpClient(handler));
+        }
+
+    }
+
+}

--- a/test/ClientWithConfigFile.cs
+++ b/test/ClientWithConfigFile.cs
@@ -60,7 +60,6 @@ namespace Ovh.Test
             CreateConfigFileWithEndpointOnly();
             Client client = new Client();
             Assert.AreEqual(client.Endpoint, "https://eu.api.ovh.com/1.0/");
-            long a = client.TimeDelta;
         }
 
         [Test]
@@ -72,7 +71,6 @@ namespace Ovh.Test
             Assert.AreEqual(client.ApplicationKey, "my_app_key");
             Assert.AreEqual(client.ApplicationSecret, "my_application_secret");
             Assert.AreEqual(client.ConsumerKey, "my_consumer_key");
-            long a = client.TimeDelta;
         }
     }
 }

--- a/test/Constants.cs
+++ b/test/Constants.cs
@@ -6,11 +6,6 @@ namespace Ovh.Test
         public const string APPLICATION_KEY = "APPLICATION_KEY";
         public const string APPLICATION_SECRET = "APPLICATION_SECRET";
         public const string CONSUMER_KEY = "CONSUMER_KEY";
-        public const string OVH_APP_HEADER = "X-Ovh-Application";
-        public const string OVH_CONSUMER_HEADER = "X-Ovh-Consumer";
-        public const string OVH_TIME_HEADER = "X-Ovh-Timestamp";
-        public const string OVH_SIGNATURE_HEADER = "X-Ovh-Signature";
-        public const string OVH_BATCH_HEADER = "X-Ovh-Batch";
     }
 
 }

--- a/test/Constants.cs
+++ b/test/Constants.cs
@@ -1,0 +1,16 @@
+namespace Ovh.Test
+{
+    public static class Constants
+    {
+        public const string ENDPOINT = "ovh-eu";
+        public const string APPLICATION_KEY = "APPLICATION_KEY";
+        public const string APPLICATION_SECRET = "APPLICATION_SECRET";
+        public const string CONSUMER_KEY = "CONSUMER_KEY";
+        public const string OVH_APP_HEADER = "X-Ovh-Application";
+        public const string OVH_CONSUMER_HEADER = "X-Ovh-Consumer";
+        public const string OVH_TIME_HEADER = "X-Ovh-Timestamp";
+        public const string OVH_SIGNATURE_HEADER = "X-Ovh-Signature";
+        public const string OVH_BATCH_HEADER = "X-Ovh-Batch";
+    }
+
+}

--- a/test/DeleteRequests.cs
+++ b/test/DeleteRequests.cs
@@ -1,0 +1,82 @@
+using System.Net.Http;
+using NUnit.Framework;
+using Ovh.Api;
+using Ovh.Api.Testing;
+using System;
+using FakeItEasy;
+using System.Linq;
+
+namespace Ovh.Test
+{
+    [TestFixture]
+    public class DeleteRequests
+    {
+        static long currentClientTimestamp = 1566485765;
+        static long currentServerTimestamp = 1566485767;
+        static DateTimeOffset currentDateTime = DateTimeOffset.FromUnixTimeSeconds(currentClientTimestamp);
+        static ITimeProvider timeProvider = A.Fake<ITimeProvider>();
+
+        public DeleteRequests()
+        {
+            A.CallTo(() => timeProvider.UtcNow).Returns(currentDateTime);
+        }
+
+        public static void MockAuthTimeCallWithFakeItEasy(FakeHttpMessageHandler fake)
+        {
+            A.CallTo(() =>
+                fake.Send(A<HttpRequestMessage>.That.Matches(
+                    r => r.RequestUri.ToString().Contains("/auth/time"))))
+                .Returns(Responses.Get.time_message);
+        }
+
+        [Test]
+        public void DELETE_as_string()
+        {
+            var fake = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
+            MockAuthTimeCallWithFakeItEasy(fake);
+
+            A.CallTo(() =>
+                fake.Send(A<HttpRequestMessage>.That.Matches(
+                    r => r.RequestUri.ToString().Contains("/ip/127.0.0.1"))))
+                .Returns(Responses.Delete.nullAsHttpResponseMessage);
+
+            var c = ClientFactory.GetClient(fake);
+            var result = c.DeleteAsync("/ip/127.0.0.1").Result;
+            Assert.AreEqual(Responses.Delete.nullAsJsonString, result);
+
+            var meCall = Fake.GetCalls(fake).Where(call =>
+                call.Method.Name == "Send" &&
+                call.GetArgument<HttpRequestMessage>("request").RequestUri.ToString().Contains("/ip/127.0.0.1")).First();
+
+            var requestMessage = meCall.GetArgument<HttpRequestMessage>("request");
+            var headers = requestMessage.Headers;
+            Assert.Multiple(() => {
+                Assert.AreEqual(Constants.APPLICATION_KEY, headers.GetValues(Constants.OVH_APP_HEADER).First());
+                Assert.AreEqual(Constants.CONSUMER_KEY, headers.GetValues(Constants.OVH_CONSUMER_HEADER).First());
+                Assert.AreEqual(currentServerTimestamp.ToString(), headers.GetValues(Constants.OVH_TIME_HEADER).First());
+                Assert.AreEqual("$1$610ebc657a19d6b444264f998291a4f24bc3227d", headers.GetValues(Constants.OVH_SIGNATURE_HEADER).First());
+            });
+        }
+
+        [Test]
+        public void DELETE_as_T()
+        {
+            var fake = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
+            MockAuthTimeCallWithFakeItEasy(fake);
+
+            A.CallTo(() =>
+                fake.Send(A<HttpRequestMessage>.That.Matches(
+                    r => r.RequestUri.ToString().Contains("/ip/127.0.0.1"))))
+                .Returns(Responses.Get.empty_message);
+
+
+            var c = ClientFactory.GetClient(fake);
+            var queryParams = new QueryStringParams();
+            queryParams.Add("filter", "value:&é'-");
+            queryParams.Add("anotherfilter", "=test");
+            var result = c.DeleteAsync<object>("/ip/127.0.0.1").Result;
+            Assert.IsNull(result);
+        }
+    }
+}
+

--- a/test/DeleteRequests.cs
+++ b/test/DeleteRequests.cs
@@ -5,6 +5,7 @@ using Ovh.Api.Testing;
 using System;
 using FakeItEasy;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Ovh.Test
 {
@@ -30,7 +31,7 @@ namespace Ovh.Test
         }
 
         [Test]
-        public void DELETE_as_string()
+        public async Task DELETE_as_string()
         {
             var fake = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
             MockAuthTimeCallWithFakeItEasy(fake);
@@ -41,7 +42,7 @@ namespace Ovh.Test
                 .Returns(Responses.Delete.nullAsHttpResponseMessage);
 
             var c = ClientFactory.GetClient(fake);
-            var result = c.DeleteAsync("/ip/127.0.0.1").Result;
+            var result = await c.DeleteAsync("/ip/127.0.0.1");
             Assert.AreEqual(Responses.Delete.nullAsJsonString, result);
 
             var meCall = Fake.GetCalls(fake).Where(call =>
@@ -51,15 +52,15 @@ namespace Ovh.Test
             var requestMessage = meCall.GetArgument<HttpRequestMessage>("request");
             var headers = requestMessage.Headers;
             Assert.Multiple(() => {
-                Assert.AreEqual(Constants.APPLICATION_KEY, headers.GetValues(Constants.OVH_APP_HEADER).First());
-                Assert.AreEqual(Constants.CONSUMER_KEY, headers.GetValues(Constants.OVH_CONSUMER_HEADER).First());
-                Assert.AreEqual(currentServerTimestamp.ToString(), headers.GetValues(Constants.OVH_TIME_HEADER).First());
-                Assert.AreEqual("$1$610ebc657a19d6b444264f998291a4f24bc3227d", headers.GetValues(Constants.OVH_SIGNATURE_HEADER).First());
+                Assert.AreEqual(Constants.APPLICATION_KEY, headers.GetValues(Client.OVH_APP_HEADER).First());
+                Assert.AreEqual(Constants.CONSUMER_KEY, headers.GetValues(Client.OVH_CONSUMER_HEADER).First());
+                Assert.AreEqual(currentServerTimestamp.ToString(), headers.GetValues(Client.OVH_TIME_HEADER).First());
+                Assert.AreEqual("$1$610ebc657a19d6b444264f998291a4f24bc3227d", headers.GetValues(Client.OVH_SIGNATURE_HEADER).First());
             });
         }
 
         [Test]
-        public void DELETE_as_T()
+        public async Task DELETE_as_T()
         {
             var fake = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
             MockAuthTimeCallWithFakeItEasy(fake);
@@ -74,7 +75,7 @@ namespace Ovh.Test
             var queryParams = new QueryStringParams();
             queryParams.Add("filter", "value:&é'-");
             queryParams.Add("anotherfilter", "=test");
-            var result = c.DeleteAsync<object>("/ip/127.0.0.1").Result;
+            var result = await c.DeleteAsync<object>("/ip/127.0.0.1");
             Assert.IsNull(result);
         }
     }

--- a/test/FakeHttpMessageHandler.cs
+++ b/test/FakeHttpMessageHandler.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Ovh.Test
+{
+    public class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        public FakeHttpMessageHandler(Dictionary<string, List<string>> expectedHeaders = null) {}
+
+        public virtual HttpResponseMessage Send(HttpRequestMessage request)
+        {
+            throw new NotImplementedException("Now we can setup this method with our mocking framework");
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
+        {
+            return Task.FromResult(Send(request));
+        }
+    }
+}

--- a/test/GetRequests.cs
+++ b/test/GetRequests.cs
@@ -1,0 +1,125 @@
+using System.Net.Http;
+using NUnit.Framework;
+using Ovh.Api;
+using Ovh.Api.Testing;
+using System;
+using FakeItEasy;
+using System.Linq;
+using Ovh.Test.Models;
+
+namespace Ovh.Test
+{
+    [TestFixture]
+    public class GetRequests
+    {
+        static long currentClientTimestamp = 1566485765;
+        static long currentServerTimestamp = 1566485767;
+        static DateTimeOffset currentDateTime = DateTimeOffset.FromUnixTimeSeconds(currentClientTimestamp);
+        static ITimeProvider timeProvider = A.Fake<ITimeProvider>();
+
+        public GetRequests()
+        {
+            A.CallTo(() => timeProvider.UtcNow).Returns(currentDateTime);
+        }
+
+        public static void MockAuthTimeCallWithFakeItEasy(FakeHttpMessageHandler fake)
+        {
+            A.CallTo(() =>
+                fake.Send(A<HttpRequestMessage>.That.Matches(
+                    r => r.RequestUri.ToString().Contains("/auth/time"))))
+                .Returns(Responses.Get.time_message);
+        }
+
+        [Test]
+        public void GET_auth_time()
+        {
+            var testHandler = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
+            MockAuthTimeCallWithFakeItEasy(testHandler);
+
+            var httpClient = new HttpClient(testHandler);
+            var c = new Client("ovh-eu", httpClient: httpClient).AsTestable(timeProvider);
+
+            Assert.AreEqual(2, c.TimeDelta);
+        }
+
+        [Test]
+        public void GET_me_as_string()
+        {
+            var fake = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
+            MockAuthTimeCallWithFakeItEasy(fake);
+
+            A.CallTo(() =>
+                fake.Send(A<HttpRequestMessage>.That.Matches(
+                    r => r.RequestUri.ToString().Contains("/me"))))
+                .Returns(Responses.Get.me_message);
+
+
+            var c = ClientFactory.GetClient(fake);
+            var result = c.GetAsync("/me").Result;
+            Assert.AreEqual(Responses.Get.me_content, result);
+
+            var meCall = Fake.GetCalls(fake).Where(call =>
+                call.Method.Name == "Send" &&
+                call.GetArgument<HttpRequestMessage>("request").RequestUri.ToString().Contains("/me")).First();
+
+            var requestMessage = meCall.GetArgument<HttpRequestMessage>("request");
+            var headers = requestMessage.Headers;
+            Assert.Multiple(() => {
+                Assert.AreEqual(Constants.APPLICATION_KEY, headers.GetValues(Constants.OVH_APP_HEADER).First());
+                Assert.AreEqual(Constants.CONSUMER_KEY, headers.GetValues(Constants.OVH_CONSUMER_HEADER).First());
+                Assert.AreEqual(currentServerTimestamp.ToString(), headers.GetValues(Constants.OVH_TIME_HEADER).First());
+                Assert.AreEqual("$1$dfe0b86bf2ab0d9eb3f785dc1ab00de58984d80c", headers.GetValues(Constants.OVH_SIGNATURE_HEADER).First());
+            });
+        }
+
+        [Test]
+        public void GET_me_as_T()
+        {
+            var fake = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
+            MockAuthTimeCallWithFakeItEasy(fake);
+
+            A.CallTo(() =>
+                fake.Send(A<HttpRequestMessage>.That.Matches(
+                    r => r.RequestUri.ToString().Contains("/me"))))
+                .Returns(Responses.Get.me_message);
+
+
+            var c = ClientFactory.GetClient(fake);
+            var result = c.GetAsync<Me>("/me").Result;
+
+            Assert.AreEqual("Noname", result.name);
+            Assert.AreEqual("none-ovh", result.nichandle);
+            Assert.AreEqual("EUR", result.currency.code);
+            Assert.AreEqual("€", result.currency.symbol);
+        }
+
+        [Test]
+        public void GET_with_filter_generates_correct_signature()
+        {
+            var fake = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
+            MockAuthTimeCallWithFakeItEasy(fake);
+
+            A.CallTo(() =>
+                fake.Send(A<HttpRequestMessage>.That.Matches(
+                    r => r.RequestUri.ToString().Contains("/route"))))
+                .Returns(Responses.Get.empty_message);
+
+
+            var c = ClientFactory.GetClient(fake);
+            var queryParams = new QueryStringParams();
+            queryParams.Add("filter", "value:&é'-");
+            queryParams.Add("anotherfilter", "=test");
+            _ = c.GetAsync("/route", queryParams).Result;
+
+
+            var meCall = Fake.GetCalls(fake).Where(call =>
+                call.Method.Name == "Send" &&
+                call.GetArgument<HttpRequestMessage>("request").RequestUri.ToString().Contains("/route")).First();
+
+            var requestMessage = meCall.GetArgument<HttpRequestMessage>("request");
+            var headers = requestMessage.Headers;
+            Assert.AreEqual("$1$098b93d342b6db4848ec448063be2b6884e94723", headers.GetValues(Constants.OVH_SIGNATURE_HEADER).First());
+        }
+    }
+}
+

--- a/test/PostRequests.cs
+++ b/test/PostRequests.cs
@@ -1,0 +1,153 @@
+using System.Net.Http;
+using NUnit.Framework;
+using Ovh.Api;
+using Ovh.Api.Testing;
+using System;
+using FakeItEasy;
+using System.Linq;
+using Ovh.Test.Models;
+using Newtonsoft.Json;
+
+namespace Ovh.Test
+{
+    [TestFixture]
+    public class PostRequests
+    {
+        static long currentClientTimestamp = 1566485765;
+        static long currentServerTimestamp = 1566485767;
+        static DateTimeOffset currentDateTime = DateTimeOffset.FromUnixTimeSeconds(currentClientTimestamp);
+        static ITimeProvider timeProvider = A.Fake<ITimeProvider>();
+
+        public PostRequests()
+        {
+            A.CallTo(() => timeProvider.UtcNow).Returns(currentDateTime);
+        }
+
+        public static void MockAuthTimeCallWithFakeItEasy(FakeHttpMessageHandler fake)
+        {
+            A.CallTo(() =>
+                fake.Send(A<HttpRequestMessage>.That.Matches(
+                    r => r.RequestUri.ToString().Contains("/auth/time"))))
+                .Returns(Responses.Get.time_message);
+        }
+
+        [Test]
+        public void POST_with_no_data_and_result_as_string()
+        {
+            var testHandler = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
+            MockAuthTimeCallWithFakeItEasy(testHandler);
+            A.CallTo(() =>
+                testHandler.Send(A<HttpRequestMessage>.That.Matches(
+                    r => r.RequestUri.ToString().Contains("/me/geolocation"))))
+                .Returns(Responses.Post.me_geolocation_message);
+
+            var c = ClientFactory.GetClient(testHandler).AsTestable(timeProvider);
+            var result = c.PostAsync("/me/geolocation", null).Result;
+            Assert.AreEqual(Responses.Post.me_geolocation_content, result);
+
+            var geolocCall = Fake.GetCalls(testHandler).Where(call =>
+                call.Method.Name == "Send" &&
+                call.GetArgument<HttpRequestMessage>("request").RequestUri.ToString().Contains("/me/geolocation")).First();
+
+            var requestMessage = geolocCall.GetArgument<HttpRequestMessage>("request");
+            var headers = requestMessage.Headers;
+            Assert.Multiple(() => {
+                Assert.AreEqual(Constants.APPLICATION_KEY, headers.GetValues(Constants.OVH_APP_HEADER).First());
+                Assert.AreEqual(Constants.CONSUMER_KEY, headers.GetValues(Constants.OVH_CONSUMER_HEADER).First());
+                Assert.AreEqual(currentServerTimestamp.ToString(), headers.GetValues(Constants.OVH_TIME_HEADER).First());
+                Assert.AreEqual("$1$3473ad8790d09e6d28f8a9d6f09a05c1f5f0bbfc", headers.GetValues(Constants.OVH_SIGNATURE_HEADER).First());
+            });
+        }
+
+        [Test]
+        public void POST_with_no_data_and_result_as_T()
+        {
+            var testHandler = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
+            MockAuthTimeCallWithFakeItEasy(testHandler);
+            A.CallTo(() =>
+                testHandler.Send(A<HttpRequestMessage>.That.Matches(
+                    r => r.RequestUri.ToString().Contains("/me/geolocation"))))
+                .Returns(Responses.Post.me_geolocation_message);
+
+            var c = ClientFactory.GetClient(testHandler).AsTestable(timeProvider);
+            var result = c.PostAsync<Geolocation>("/me/geolocation", null).Result;
+            Assert.AreEqual("eo", result.countryCode);
+            Assert.AreEqual("256.0.0.1", result.ip);
+            Assert.AreEqual("Atlantis", result.continent);
+        }
+
+        [Test]
+        public void POST_with_string_data_and_result_as_string()
+        {
+            var testHandler = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
+            MockAuthTimeCallWithFakeItEasy(testHandler);
+            A.CallTo(() =>
+                testHandler.Send(A<HttpRequestMessage>.That.Matches(
+                    r => r.RequestUri.ToString().Contains("/me/contact"))))
+                .Returns(Responses.Post.me_contact_message);
+
+            var c = ClientFactory.GetClient(testHandler).AsTestable(timeProvider);
+            var result = c.PostAsync("/me/contact", "Fake content").Result;
+            Assert.AreEqual(Responses.Post.me_contact_content, result);
+
+            var contactCall = Fake.GetCalls(testHandler).Where(call =>
+                call.Method.Name == "Send" &&
+                call.GetArgument<HttpRequestMessage>("request").RequestUri.ToString().Contains("/me/contact")).First();
+
+            var requestMessage = contactCall.GetArgument<HttpRequestMessage>("request");
+            var headers = requestMessage.Headers;
+            Assert.Multiple(() => {
+                Assert.AreEqual(Constants.APPLICATION_KEY, headers.GetValues(Constants.OVH_APP_HEADER).First());
+                Assert.AreEqual(Constants.CONSUMER_KEY, headers.GetValues(Constants.OVH_CONSUMER_HEADER).First());
+                Assert.AreEqual(currentServerTimestamp.ToString(), headers.GetValues(Constants.OVH_TIME_HEADER).First());
+                Assert.AreEqual("$1$19a8f2db1a3b2b89b231c7872332b6ba117d8bd7", headers.GetValues(Constants.OVH_SIGNATURE_HEADER).First());
+            });
+        }
+
+        [Test]
+        public void POST_with_T_data_and_result_as_string()
+        {
+            var testHandler = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
+            MockAuthTimeCallWithFakeItEasy(testHandler);
+            var dummyContact = new Contact{
+                address = new Address{
+                    city = "deleteme",
+                    country = "FR",
+                    line1 = "deleteme",
+                    zip = "00000"
+                },
+                email = "deleteme@deleteme.deleteme",
+                firstName = "deleteme",
+                language = "fr_FR",
+                lastName = "deleteme",
+                legalForm = "individual",
+                phone = "0000000000"
+            };
+            A.CallTo(() =>
+                testHandler.Send(A<HttpRequestMessage>.That.Matches(
+                    r => r.RequestUri.ToString().Contains("/me/contact"))))
+                .Returns(Responses.Post.me_contact_message);
+
+            var lol = JsonConvert.SerializeObject(dummyContact);
+
+            var c = ClientFactory.GetClient(testHandler).AsTestable(timeProvider);
+            var result = c.PostAsync<Contact, Contact>("/me/contact", dummyContact).Result;
+
+            //Ensure that the call went through correctly
+            Assert.AreEqual(123456, result.id);
+
+            var contactCall = Fake.GetCalls(testHandler).Where(call =>
+                call.Method.Name == "Send" &&
+                call.GetArgument<HttpRequestMessage>("request").RequestUri.ToString().Contains("/me/contact")).First();
+
+            var requestMessage = contactCall.GetArgument<HttpRequestMessage>("request");
+
+            // Ensure that we sent a serialized version of the dummy contact
+            var sendtObject = JsonConvert.DeserializeObject<Contact>(requestMessage.Content.ReadAsStringAsync().Result);
+            Assert.AreEqual(dummyContact.address.country, sendtObject.address.country);
+            Assert.AreEqual(dummyContact.address.zip, sendtObject.address.zip);
+            Assert.AreEqual(dummyContact.email, sendtObject.email);
+        }
+    }
+}
+

--- a/test/PostRequests.cs
+++ b/test/PostRequests.cs
@@ -7,6 +7,7 @@ using FakeItEasy;
 using System.Linq;
 using Ovh.Test.Models;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace Ovh.Test
 {
@@ -32,7 +33,7 @@ namespace Ovh.Test
         }
 
         [Test]
-        public void POST_with_no_data_and_result_as_string()
+        public async Task OST_with_no_data_and_result_as_string()
         {
             var testHandler = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
             MockAuthTimeCallWithFakeItEasy(testHandler);
@@ -42,7 +43,7 @@ namespace Ovh.Test
                 .Returns(Responses.Post.me_geolocation_message);
 
             var c = ClientFactory.GetClient(testHandler).AsTestable(timeProvider);
-            var result = c.PostAsync("/me/geolocation", null).Result;
+            var result = await c.PostAsync("/me/geolocation", null);
             Assert.AreEqual(Responses.Post.me_geolocation_content, result);
 
             var geolocCall = Fake.GetCalls(testHandler).Where(call =>
@@ -52,15 +53,15 @@ namespace Ovh.Test
             var requestMessage = geolocCall.GetArgument<HttpRequestMessage>("request");
             var headers = requestMessage.Headers;
             Assert.Multiple(() => {
-                Assert.AreEqual(Constants.APPLICATION_KEY, headers.GetValues(Constants.OVH_APP_HEADER).First());
-                Assert.AreEqual(Constants.CONSUMER_KEY, headers.GetValues(Constants.OVH_CONSUMER_HEADER).First());
-                Assert.AreEqual(currentServerTimestamp.ToString(), headers.GetValues(Constants.OVH_TIME_HEADER).First());
-                Assert.AreEqual("$1$3473ad8790d09e6d28f8a9d6f09a05c1f5f0bbfc", headers.GetValues(Constants.OVH_SIGNATURE_HEADER).First());
+                Assert.AreEqual(Constants.APPLICATION_KEY, headers.GetValues(Client.OVH_APP_HEADER).First());
+                Assert.AreEqual(Constants.CONSUMER_KEY, headers.GetValues(Client.OVH_CONSUMER_HEADER).First());
+                Assert.AreEqual(currentServerTimestamp.ToString(), headers.GetValues(Client.OVH_TIME_HEADER).First());
+                Assert.AreEqual("$1$3473ad8790d09e6d28f8a9d6f09a05c1f5f0bbfc", headers.GetValues(Client.OVH_SIGNATURE_HEADER).First());
             });
         }
 
         [Test]
-        public void POST_with_no_data_and_result_as_T()
+        public async Task OST_with_no_data_and_result_as_T()
         {
             var testHandler = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
             MockAuthTimeCallWithFakeItEasy(testHandler);
@@ -70,14 +71,14 @@ namespace Ovh.Test
                 .Returns(Responses.Post.me_geolocation_message);
 
             var c = ClientFactory.GetClient(testHandler).AsTestable(timeProvider);
-            var result = c.PostAsync<Geolocation>("/me/geolocation", null).Result;
+            var result = await c.PostAsync<Geolocation>("/me/geolocation", null);
             Assert.AreEqual("eo", result.countryCode);
             Assert.AreEqual("256.0.0.1", result.ip);
             Assert.AreEqual("Atlantis", result.continent);
         }
 
         [Test]
-        public void POST_with_string_data_and_result_as_string()
+        public async Task OST_with_string_data_and_result_as_string()
         {
             var testHandler = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
             MockAuthTimeCallWithFakeItEasy(testHandler);
@@ -87,7 +88,7 @@ namespace Ovh.Test
                 .Returns(Responses.Post.me_contact_message);
 
             var c = ClientFactory.GetClient(testHandler).AsTestable(timeProvider);
-            var result = c.PostAsync("/me/contact", "Fake content").Result;
+            var result = await c.PostAsync("/me/contact", "Fake content");
             Assert.AreEqual(Responses.Post.me_contact_content, result);
 
             var contactCall = Fake.GetCalls(testHandler).Where(call =>
@@ -97,15 +98,15 @@ namespace Ovh.Test
             var requestMessage = contactCall.GetArgument<HttpRequestMessage>("request");
             var headers = requestMessage.Headers;
             Assert.Multiple(() => {
-                Assert.AreEqual(Constants.APPLICATION_KEY, headers.GetValues(Constants.OVH_APP_HEADER).First());
-                Assert.AreEqual(Constants.CONSUMER_KEY, headers.GetValues(Constants.OVH_CONSUMER_HEADER).First());
-                Assert.AreEqual(currentServerTimestamp.ToString(), headers.GetValues(Constants.OVH_TIME_HEADER).First());
-                Assert.AreEqual("$1$19a8f2db1a3b2b89b231c7872332b6ba117d8bd7", headers.GetValues(Constants.OVH_SIGNATURE_HEADER).First());
+                Assert.AreEqual(Constants.APPLICATION_KEY, headers.GetValues(Client.OVH_APP_HEADER).First());
+                Assert.AreEqual(Constants.CONSUMER_KEY, headers.GetValues(Client.OVH_CONSUMER_HEADER).First());
+                Assert.AreEqual(currentServerTimestamp.ToString(), headers.GetValues(Client.OVH_TIME_HEADER).First());
+                Assert.AreEqual("$1$19a8f2db1a3b2b89b231c7872332b6ba117d8bd7", headers.GetValues(Client.OVH_SIGNATURE_HEADER).First());
             });
         }
 
         [Test]
-        public void POST_with_T_data_and_result_as_string()
+        public async Task OST_with_T_data_and_result_as_string()
         {
             var testHandler = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
             MockAuthTimeCallWithFakeItEasy(testHandler);
@@ -131,7 +132,7 @@ namespace Ovh.Test
             var lol = JsonConvert.SerializeObject(dummyContact);
 
             var c = ClientFactory.GetClient(testHandler).AsTestable(timeProvider);
-            var result = c.PostAsync<Contact, Contact>("/me/contact", dummyContact).Result;
+            var result = await c.PostAsync<Contact, Contact>("/me/contact", dummyContact);
 
             //Ensure that the call went through correctly
             Assert.AreEqual(123456, result.id);
@@ -143,7 +144,7 @@ namespace Ovh.Test
             var requestMessage = contactCall.GetArgument<HttpRequestMessage>("request");
 
             // Ensure that we sent a serialized version of the dummy contact
-            var sendtObject = JsonConvert.DeserializeObject<Contact>(requestMessage.Content.ReadAsStringAsync().Result);
+            var sendtObject = JsonConvert.DeserializeObject<Contact>(await requestMessage.Content.ReadAsStringAsync());
             Assert.AreEqual(dummyContact.address.country, sendtObject.address.country);
             Assert.AreEqual(dummyContact.address.zip, sendtObject.address.zip);
             Assert.AreEqual(dummyContact.email, sendtObject.email);

--- a/test/PutRequests.cs
+++ b/test/PutRequests.cs
@@ -1,0 +1,101 @@
+using System.Net.Http;
+using NUnit.Framework;
+using Ovh.Api.Testing;
+using System;
+using FakeItEasy;
+using System.Linq;
+using Ovh.Test.Models;
+
+namespace Ovh.Test
+{
+    [TestFixture]
+    public class PutRequests
+    {
+        static long currentClientTimestamp = 1566485765;
+        static long currentServerTimestamp = 1566485767;
+        static DateTimeOffset currentDateTime = DateTimeOffset.FromUnixTimeSeconds(currentClientTimestamp);
+        static ITimeProvider timeProvider = A.Fake<ITimeProvider>();
+
+        public PutRequests()
+        {
+            A.CallTo(() => timeProvider.UtcNow).Returns(currentDateTime);
+        }
+
+        public static void MockAuthTimeCallWithFakeItEasy(FakeHttpMessageHandler fake)
+        {
+            A.CallTo(() =>
+                fake.Send(A<HttpRequestMessage>.That.Matches(
+                    r => r.RequestUri.ToString().Contains("/auth/time"))))
+                .Returns(Responses.Get.time_message);
+        }
+
+        [Test]
+        public void PUT_with_data_as_string_and_result_as_string()
+        {
+            var testHandler = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
+            MockAuthTimeCallWithFakeItEasy(testHandler);
+            A.CallTo(() =>
+                testHandler.Send(A<HttpRequestMessage>.That.Matches(
+                    r => r.RequestUri.ToString().Contains("/me/contact"))))
+                .Returns(Responses.Put.me_contact_message);
+
+            var c = ClientFactory.GetClient(testHandler).AsTestable(timeProvider);
+            var result = c.PutAsync("/me/contact", "Fake content").Result;
+            Assert.AreEqual(Responses.Put.me_contact_content, result);
+
+            var contactCall = Fake.GetCalls(testHandler).Where(call =>
+                call.Method.Name == "Send" &&
+                call.GetArgument<HttpRequestMessage>("request").RequestUri.ToString().Contains("/me/contact")).First();
+
+            var requestMessage = contactCall.GetArgument<HttpRequestMessage>("request");
+            var headers = requestMessage.Headers;
+            Assert.Multiple(() => {
+                Assert.AreEqual(HttpMethod.Put, requestMessage.Method);
+                Assert.AreEqual(Constants.APPLICATION_KEY, headers.GetValues(Constants.OVH_APP_HEADER).First());
+                Assert.AreEqual(Constants.CONSUMER_KEY, headers.GetValues(Constants.OVH_CONSUMER_HEADER).First());
+                Assert.AreEqual(currentServerTimestamp.ToString(), headers.GetValues(Constants.OVH_TIME_HEADER).First());
+                Assert.AreEqual("$1$5e81842c0f0c806fd703de084d80192a59bc0f8a", headers.GetValues(Constants.OVH_SIGNATURE_HEADER).First());
+            });
+        }
+
+        [Test]
+        public void PUT_with_data_as_string_and_result_as_T()
+        {
+            var testHandler = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
+            MockAuthTimeCallWithFakeItEasy(testHandler);
+            A.CallTo(() =>
+                testHandler.Send(A<HttpRequestMessage>.That.Matches(
+                    r => r.RequestUri.ToString().Contains("/me/contact"))))
+                .Returns(Responses.Put.me_contact_message);
+
+            var c = ClientFactory.GetClient(testHandler).AsTestable(timeProvider);
+            var result = c.PutAsync<Contact>("/me/contact", "Fake content").Result;
+            Assert.AreEqual("00000", result.address.zip);
+        }
+
+        [Test]
+        public void PUT_with_data_as_T_and_result_as_T()
+        {
+            var testHandler = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
+            MockAuthTimeCallWithFakeItEasy(testHandler);
+            A.CallTo(() =>
+                testHandler.Send(A<HttpRequestMessage>.That.Matches(
+                    r => r.RequestUri.ToString().Contains("/me/contact"))))
+                .Returns(Responses.Put.me_contact_message);
+
+            var patch = new {address = new {line1 = "Hey there"} };
+
+            var c = ClientFactory.GetClient(testHandler).AsTestable(timeProvider);
+            var result = c.PutAsync<Contact, object>("/me/contact", patch).Result;
+            Assert.AreEqual("00000", result.address.zip);
+
+            var contactCall = Fake.GetCalls(testHandler).Where(call =>
+                call.Method.Name == "Send" &&
+                call.GetArgument<HttpRequestMessage>("request").RequestUri.ToString().Contains("/me/contact")).First();
+
+            var requestMessage = contactCall.GetArgument<HttpRequestMessage>("request");
+            var headers = requestMessage.Headers;
+            Assert.AreEqual("$1$747cdaf92e412ea434a387e6ff7b20150ee1172f", headers.GetValues(Constants.OVH_SIGNATURE_HEADER).First());
+        }
+    }
+}

--- a/test/PutRequests.cs
+++ b/test/PutRequests.cs
@@ -5,6 +5,8 @@ using System;
 using FakeItEasy;
 using System.Linq;
 using Ovh.Test.Models;
+using Ovh.Api;
+using System.Threading.Tasks;
 
 namespace Ovh.Test
 {
@@ -30,7 +32,7 @@ namespace Ovh.Test
         }
 
         [Test]
-        public void PUT_with_data_as_string_and_result_as_string()
+        public async Task UT_with_data_as_string_and_result_as_string()
         {
             var testHandler = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
             MockAuthTimeCallWithFakeItEasy(testHandler);
@@ -40,7 +42,7 @@ namespace Ovh.Test
                 .Returns(Responses.Put.me_contact_message);
 
             var c = ClientFactory.GetClient(testHandler).AsTestable(timeProvider);
-            var result = c.PutAsync("/me/contact", "Fake content").Result;
+            var result = await c.PutAsync("/me/contact", "Fake content");
             Assert.AreEqual(Responses.Put.me_contact_content, result);
 
             var contactCall = Fake.GetCalls(testHandler).Where(call =>
@@ -51,15 +53,15 @@ namespace Ovh.Test
             var headers = requestMessage.Headers;
             Assert.Multiple(() => {
                 Assert.AreEqual(HttpMethod.Put, requestMessage.Method);
-                Assert.AreEqual(Constants.APPLICATION_KEY, headers.GetValues(Constants.OVH_APP_HEADER).First());
-                Assert.AreEqual(Constants.CONSUMER_KEY, headers.GetValues(Constants.OVH_CONSUMER_HEADER).First());
-                Assert.AreEqual(currentServerTimestamp.ToString(), headers.GetValues(Constants.OVH_TIME_HEADER).First());
-                Assert.AreEqual("$1$5e81842c0f0c806fd703de084d80192a59bc0f8a", headers.GetValues(Constants.OVH_SIGNATURE_HEADER).First());
+                Assert.AreEqual(Constants.APPLICATION_KEY, headers.GetValues(Client.OVH_APP_HEADER).First());
+                Assert.AreEqual(Constants.CONSUMER_KEY, headers.GetValues(Client.OVH_CONSUMER_HEADER).First());
+                Assert.AreEqual(currentServerTimestamp.ToString(), headers.GetValues(Client.OVH_TIME_HEADER).First());
+                Assert.AreEqual("$1$5e81842c0f0c806fd703de084d80192a59bc0f8a", headers.GetValues(Client.OVH_SIGNATURE_HEADER).First());
             });
         }
 
         [Test]
-        public void PUT_with_data_as_string_and_result_as_T()
+        public async Task UT_with_data_as_string_and_result_as_T()
         {
             var testHandler = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
             MockAuthTimeCallWithFakeItEasy(testHandler);
@@ -69,12 +71,12 @@ namespace Ovh.Test
                 .Returns(Responses.Put.me_contact_message);
 
             var c = ClientFactory.GetClient(testHandler).AsTestable(timeProvider);
-            var result = c.PutAsync<Contact>("/me/contact", "Fake content").Result;
+            var result = await c.PutAsync<Contact>("/me/contact", "Fake content");
             Assert.AreEqual("00000", result.address.zip);
         }
 
         [Test]
-        public void PUT_with_data_as_T_and_result_as_T()
+        public async Task UT_with_data_as_T_and_result_as_T()
         {
             var testHandler = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
             MockAuthTimeCallWithFakeItEasy(testHandler);
@@ -86,7 +88,7 @@ namespace Ovh.Test
             var patch = new {address = new {line1 = "Hey there"} };
 
             var c = ClientFactory.GetClient(testHandler).AsTestable(timeProvider);
-            var result = c.PutAsync<Contact, object>("/me/contact", patch).Result;
+            var result = await c.PutAsync<Contact, object>("/me/contact", patch);
             Assert.AreEqual("00000", result.address.zip);
 
             var contactCall = Fake.GetCalls(testHandler).Where(call =>
@@ -95,7 +97,7 @@ namespace Ovh.Test
 
             var requestMessage = contactCall.GetArgument<HttpRequestMessage>("request");
             var headers = requestMessage.Headers;
-            Assert.AreEqual("$1$747cdaf92e412ea434a387e6ff7b20150ee1172f", headers.GetValues(Constants.OVH_SIGNATURE_HEADER).First());
+            Assert.AreEqual("$1$747cdaf92e412ea434a387e6ff7b20150ee1172f", headers.GetValues(Client.OVH_SIGNATURE_HEADER).First());
         }
     }
 }

--- a/test/Responses/DeleteResponses.cs
+++ b/test/Responses/DeleteResponses.cs
@@ -1,0 +1,15 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+
+namespace Ovh.Test.Responses
+{
+    public static class Delete
+    {
+        public static string nullAsJsonString = "null";
+        public static HttpResponseMessage nullAsHttpResponseMessage = new HttpResponseMessage{
+            Content = new StringContent(nullAsJsonString, Encoding.UTF8, "application/json"),
+            StatusCode = HttpStatusCode.OK
+        };
+    }
+}

--- a/test/Responses/DeleteResponses.cs
+++ b/test/Responses/DeleteResponses.cs
@@ -1,15 +1,12 @@
 using System.Net;
 using System.Net.Http;
-using System.Text;
 
 namespace Ovh.Test.Responses
 {
     public static class Delete
     {
-        public static string nullAsJsonString = "null";
-        public static HttpResponseMessage nullAsHttpResponseMessage = new HttpResponseMessage{
-            Content = new StringContent(nullAsJsonString, Encoding.UTF8, "application/json"),
-            StatusCode = HttpStatusCode.OK
-        };
+        public static readonly string nullAsJsonString = "null";
+        public static readonly HttpResponseMessage nullAsHttpResponseMessage =
+            HttpResponseMessageFactory.Create(nullAsJsonString, HttpStatusCode.OK);
     }
 }

--- a/test/Responses/GetResponses.cs
+++ b/test/Responses/GetResponses.cs
@@ -1,26 +1,19 @@
 using System.Net;
 using System.Net.Http;
-using System.Text;
 
 namespace Ovh.Test.Responses
 {
     public static class Get
     {
-        public static string me_content = "{\"sex\":null,\"phoneCountry\":\"FR\",\"currency\":{\"code\":\"EUR\",\"symbol\":\"€\"},\"nichandle\":\"none-ovh\",\"name\":\"Noname\",\"legalform\":\"individual\",\"city\":\"sin\",\"firstname\":\"nofname\",\"language\":\"eo_EO\",\"customerCode\":\"0000-0000-00\",\"nationalIdentificationNumber\":null,\"phone\":\"+33.000000000\",\"ovhSubsidiary\":\"EO\",\"email\":\"none@dev.null\",\"organisation\":\"\",\"area\":\"\",\"zip\":\"00000\",\"fax\":\"\",\"spareEmail\":null,\"address\":\"somewhere\",\"vat\":\"\",\"state\":\"complete\",\"birthCity\":\"\",\"country\":\"FR\",\"ovhCompany\":\"ovh\",\"corporationType\":\"\",\"italianSDI\":null,\"birthDay\":\"\",\"companyNationalIdentificationNumber\":null}";
-        public static HttpResponseMessage me_message = new HttpResponseMessage{
-            Content = new StringContent(me_content, Encoding.UTF8, "application/json"),
-            StatusCode = HttpStatusCode.OK
-        };
+        public static readonly string me_content = "{\"sex\":null,\"phoneCountry\":\"FR\",\"currency\":{\"code\":\"EUR\",\"symbol\":\"€\"},\"nichandle\":\"none-ovh\",\"name\":\"Noname\",\"legalform\":\"individual\",\"city\":\"sin\",\"firstname\":\"nofname\",\"language\":\"eo_EO\",\"customerCode\":\"0000-0000-00\",\"nationalIdentificationNumber\":null,\"phone\":\"+33.000000000\",\"ovhSubsidiary\":\"EO\",\"email\":\"none@dev.null\",\"organisation\":\"\",\"area\":\"\",\"zip\":\"00000\",\"fax\":\"\",\"spareEmail\":null,\"address\":\"somewhere\",\"vat\":\"\",\"state\":\"complete\",\"birthCity\":\"\",\"country\":\"FR\",\"ovhCompany\":\"ovh\",\"corporationType\":\"\",\"italianSDI\":null,\"birthDay\":\"\",\"companyNationalIdentificationNumber\":null}";
+        public static readonly HttpResponseMessage me_message =
+            HttpResponseMessageFactory.Create(me_content, HttpStatusCode.OK);
 
-        public static string time_content = "1566485767";
-        public static HttpResponseMessage time_message = new HttpResponseMessage{
-            Content = new StringContent(time_content, Encoding.UTF8, "application/json"),
-            StatusCode = HttpStatusCode.OK
-        };
+        public static readonly string time_content = "1566485767";
+        public static readonly HttpResponseMessage time_message =
+            HttpResponseMessageFactory.Create(time_content, HttpStatusCode.OK);
 
-        public static HttpResponseMessage empty_message = new HttpResponseMessage{
-            Content = new StringContent("", Encoding.UTF8, "application/json"),
-            StatusCode = HttpStatusCode.OK
-        };
+        public static readonly HttpResponseMessage empty_message =
+            HttpResponseMessageFactory.Create("", HttpStatusCode.OK);
     }
 }

--- a/test/Responses/GetResponses.cs
+++ b/test/Responses/GetResponses.cs
@@ -1,0 +1,26 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+
+namespace Ovh.Test.Responses
+{
+    public static class Get
+    {
+        public static string me_content = "{\"sex\":null,\"phoneCountry\":\"FR\",\"currency\":{\"code\":\"EUR\",\"symbol\":\"€\"},\"nichandle\":\"none-ovh\",\"name\":\"Noname\",\"legalform\":\"individual\",\"city\":\"sin\",\"firstname\":\"nofname\",\"language\":\"eo_EO\",\"customerCode\":\"0000-0000-00\",\"nationalIdentificationNumber\":null,\"phone\":\"+33.000000000\",\"ovhSubsidiary\":\"EO\",\"email\":\"none@dev.null\",\"organisation\":\"\",\"area\":\"\",\"zip\":\"00000\",\"fax\":\"\",\"spareEmail\":null,\"address\":\"somewhere\",\"vat\":\"\",\"state\":\"complete\",\"birthCity\":\"\",\"country\":\"FR\",\"ovhCompany\":\"ovh\",\"corporationType\":\"\",\"italianSDI\":null,\"birthDay\":\"\",\"companyNationalIdentificationNumber\":null}";
+        public static HttpResponseMessage me_message = new HttpResponseMessage{
+            Content = new StringContent(me_content, Encoding.UTF8, "application/json"),
+            StatusCode = HttpStatusCode.OK
+        };
+
+        public static string time_content = "1566485767";
+        public static HttpResponseMessage time_message = new HttpResponseMessage{
+            Content = new StringContent(time_content, Encoding.UTF8, "application/json"),
+            StatusCode = HttpStatusCode.OK
+        };
+
+        public static HttpResponseMessage empty_message = new HttpResponseMessage{
+            Content = new StringContent("", Encoding.UTF8, "application/json"),
+            StatusCode = HttpStatusCode.OK
+        };
+    }
+}

--- a/test/Responses/HttpResponseMessageFactory.cs
+++ b/test/Responses/HttpResponseMessageFactory.cs
@@ -1,0 +1,20 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+
+namespace Ovh.Test
+{
+    public static class HttpResponseMessageFactory
+    {
+        public static HttpResponseMessage Create(string content, HttpStatusCode statusCode,
+            string contentType = "application/json", Encoding encoding = null)
+        {
+            encoding = encoding ?? Encoding.UTF8;
+            return new HttpResponseMessage
+            {
+                Content = new StringContent(content, encoding, contentType),
+                StatusCode = statusCode
+            };
+        }
+    }
+}

--- a/test/Responses/Models/Address.cs
+++ b/test/Responses/Models/Address.cs
@@ -1,0 +1,11 @@
+
+namespace Ovh.Test.Models
+{
+    public class Address
+    {
+        public string city { get; set; }
+        public string country { get; set; }
+        public string line1 { get; set; }
+        public string zip { get; set; }
+    }
+}

--- a/test/Responses/Models/Contact.cs
+++ b/test/Responses/Models/Contact.cs
@@ -1,0 +1,15 @@
+
+namespace Ovh.Test.Models
+{
+    public class Contact
+    {
+        public int id { get; set; }
+        public Address address { get; set; }
+        public string email { get; set; }
+        public string firstName { get; set; }
+        public string language { get; set; }
+        public string lastName { get; set; }
+        public string legalForm { get; set; }
+        public string phone { get; set; }
+    }
+}

--- a/test/Responses/Models/Currency.cs
+++ b/test/Responses/Models/Currency.cs
@@ -1,0 +1,8 @@
+namespace Ovh.Test.Models
+{
+    public class Currency
+    {
+        public string code { get; set; }
+        public string symbol { get; set; }
+    }
+}

--- a/test/Responses/Models/Geolocation.cs
+++ b/test/Responses/Models/Geolocation.cs
@@ -1,0 +1,9 @@
+namespace Ovh.Test.Models
+{
+    public class Geolocation
+    {
+        public string countryCode { get; set; }
+        public string ip { get; set; }
+        public string continent { get; set; }
+    }
+}

--- a/test/Responses/Models/Me.cs
+++ b/test/Responses/Models/Me.cs
@@ -1,0 +1,9 @@
+namespace Ovh.Test.Models
+{
+    public class Me
+    {
+        public string nichandle { get; set; }
+        public string name { get; set; }
+        public Currency currency { get; set; }
+    }
+}

--- a/test/Responses/PostResponses.cs
+++ b/test/Responses/PostResponses.cs
@@ -1,21 +1,16 @@
 using System.Net;
 using System.Net.Http;
-using System.Text;
 
 namespace Ovh.Test.Responses
 {
     public static class Post
     {
-        public static string me_geolocation_content = "{\"countryCode\":\"eo\",\"ip\":\"256.0.0.1\",\"continent\":\"Atlantis\"}";
-        public static HttpResponseMessage me_geolocation_message = new HttpResponseMessage{
-            Content = new StringContent(me_geolocation_content, Encoding.UTF8, "application/json"),
-            StatusCode = HttpStatusCode.OK
-        };
+        public static readonly string me_geolocation_content = "{\"countryCode\":\"eo\",\"ip\":\"256.0.0.1\",\"continent\":\"Atlantis\"}";
+        public static readonly HttpResponseMessage me_geolocation_message =
+            HttpResponseMessageFactory.Create(me_geolocation_content, HttpStatusCode.OK);
 
-        public static string me_contact_content = "{\"email\":\"deleteme@deleteme.deleteme\",\"lastName\":\"deleteme\",\"birthCountry\":null,\"language\":\"fr_FR\",\"nationalIdentificationNumber\":null,\"legalForm\":\"individual\",\"gender\":null,\"organisationName\":null,\"birthCity\":null,\"birthZip\":null,\"birthDay\":null,\"companyNationalIdentificationNumber\":null,\"phone\":\"0000000000\",\"firstName\":\"deleteme\",\"address\":{\"city\":\"deleteme\",\"otherDetails\":null,\"province\":null,\"line3\":null,\"line1\":\"deleteme\",\"line2\":null,\"zip\":\"00000\",\"country\":\"FR\"},\"spareEmail\":null,\"organisationType\":null,\"fax\":null,\"nationality\":null,\"vat\":null,\"id\":123456,\"cellPhone\":null}";
-        public static HttpResponseMessage me_contact_message = new HttpResponseMessage{
-            Content = new StringContent(me_contact_content, Encoding.UTF8, "application/json"),
-            StatusCode = HttpStatusCode.OK
-        };
+        public static readonly string me_contact_content = "{\"email\":\"deleteme@deleteme.deleteme\",\"lastName\":\"deleteme\",\"birthCountry\":null,\"language\":\"fr_FR\",\"nationalIdentificationNumber\":null,\"legalForm\":\"individual\",\"gender\":null,\"organisationName\":null,\"birthCity\":null,\"birthZip\":null,\"birthDay\":null,\"companyNationalIdentificationNumber\":null,\"phone\":\"0000000000\",\"firstName\":\"deleteme\",\"address\":{\"city\":\"deleteme\",\"otherDetails\":null,\"province\":null,\"line3\":null,\"line1\":\"deleteme\",\"line2\":null,\"zip\":\"00000\",\"country\":\"FR\"},\"spareEmail\":null,\"organisationType\":null,\"fax\":null,\"nationality\":null,\"vat\":null,\"id\":123456,\"cellPhone\":null}";
+        public static readonly HttpResponseMessage me_contact_message =
+            HttpResponseMessageFactory.Create(me_contact_content, HttpStatusCode.OK);
     }
 }

--- a/test/Responses/PostResponses.cs
+++ b/test/Responses/PostResponses.cs
@@ -1,0 +1,21 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+
+namespace Ovh.Test.Responses
+{
+    public static class Post
+    {
+        public static string me_geolocation_content = "{\"countryCode\":\"eo\",\"ip\":\"256.0.0.1\",\"continent\":\"Atlantis\"}";
+        public static HttpResponseMessage me_geolocation_message = new HttpResponseMessage{
+            Content = new StringContent(me_geolocation_content, Encoding.UTF8, "application/json"),
+            StatusCode = HttpStatusCode.OK
+        };
+
+        public static string me_contact_content = "{\"email\":\"deleteme@deleteme.deleteme\",\"lastName\":\"deleteme\",\"birthCountry\":null,\"language\":\"fr_FR\",\"nationalIdentificationNumber\":null,\"legalForm\":\"individual\",\"gender\":null,\"organisationName\":null,\"birthCity\":null,\"birthZip\":null,\"birthDay\":null,\"companyNationalIdentificationNumber\":null,\"phone\":\"0000000000\",\"firstName\":\"deleteme\",\"address\":{\"city\":\"deleteme\",\"otherDetails\":null,\"province\":null,\"line3\":null,\"line1\":\"deleteme\",\"line2\":null,\"zip\":\"00000\",\"country\":\"FR\"},\"spareEmail\":null,\"organisationType\":null,\"fax\":null,\"nationality\":null,\"vat\":null,\"id\":123456,\"cellPhone\":null}";
+        public static HttpResponseMessage me_contact_message = new HttpResponseMessage{
+            Content = new StringContent(me_contact_content, Encoding.UTF8, "application/json"),
+            StatusCode = HttpStatusCode.OK
+        };
+    }
+}

--- a/test/Responses/PutResponses.cs
+++ b/test/Responses/PutResponses.cs
@@ -1,15 +1,12 @@
 using System.Net;
 using System.Net.Http;
-using System.Text;
 
 namespace Ovh.Test.Responses
 {
     public static class Put
     {
-        public static string me_contact_content = "{\"email\":\"deleteme@deleteme.deleteme\",\"lastName\":\"deleteme\",\"birthCountry\":null,\"language\":\"fr_FR\",\"nationalIdentificationNumber\":null,\"legalForm\":\"individual\",\"gender\":null,\"organisationName\":null,\"birthCity\":null,\"birthZip\":null,\"birthDay\":null,\"companyNationalIdentificationNumber\":null,\"phone\":\"0000000000\",\"firstName\":\"deleteme\",\"address\":{\"city\":\"deleteme\",\"otherDetails\":null,\"province\":null,\"line3\":null,\"line1\":\"deleteme\",\"line2\":null,\"zip\":\"00000\",\"country\":\"FR\"},\"spareEmail\":null,\"organisationType\":null,\"fax\":null,\"nationality\":null,\"vat\":null,\"id\":123456,\"cellPhone\":null}";
-        public static HttpResponseMessage me_contact_message = new HttpResponseMessage{
-            Content = new StringContent(me_contact_content, Encoding.UTF8, "application/json"),
-            StatusCode = HttpStatusCode.OK
-        };
+        public static readonly string me_contact_content = "{\"email\":\"deleteme@deleteme.deleteme\",\"lastName\":\"deleteme\",\"birthCountry\":null,\"language\":\"fr_FR\",\"nationalIdentificationNumber\":null,\"legalForm\":\"individual\",\"gender\":null,\"organisationName\":null,\"birthCity\":null,\"birthZip\":null,\"birthDay\":null,\"companyNationalIdentificationNumber\":null,\"phone\":\"0000000000\",\"firstName\":\"deleteme\",\"address\":{\"city\":\"deleteme\",\"otherDetails\":null,\"province\":null,\"line3\":null,\"line1\":\"deleteme\",\"line2\":null,\"zip\":\"00000\",\"country\":\"FR\"},\"spareEmail\":null,\"organisationType\":null,\"fax\":null,\"nationality\":null,\"vat\":null,\"id\":123456,\"cellPhone\":null}";
+        public static readonly HttpResponseMessage me_contact_message =
+            HttpResponseMessageFactory.Create(me_contact_content, HttpStatusCode.OK);
     }
 }

--- a/test/Responses/PutResponses.cs
+++ b/test/Responses/PutResponses.cs
@@ -1,0 +1,15 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+
+namespace Ovh.Test.Responses
+{
+    public static class Put
+    {
+        public static string me_contact_content = "{\"email\":\"deleteme@deleteme.deleteme\",\"lastName\":\"deleteme\",\"birthCountry\":null,\"language\":\"fr_FR\",\"nationalIdentificationNumber\":null,\"legalForm\":\"individual\",\"gender\":null,\"organisationName\":null,\"birthCity\":null,\"birthZip\":null,\"birthDay\":null,\"companyNationalIdentificationNumber\":null,\"phone\":\"0000000000\",\"firstName\":\"deleteme\",\"address\":{\"city\":\"deleteme\",\"otherDetails\":null,\"province\":null,\"line3\":null,\"line1\":\"deleteme\",\"line2\":null,\"zip\":\"00000\",\"country\":\"FR\"},\"spareEmail\":null,\"organisationType\":null,\"fax\":null,\"nationality\":null,\"vat\":null,\"id\":123456,\"cellPhone\":null}";
+        public static HttpResponseMessage me_contact_message = new HttpResponseMessage{
+            Content = new StringContent(me_contact_content, Encoding.UTF8, "application/json"),
+            StatusCode = HttpStatusCode.OK
+        };
+    }
+}

--- a/test/Signatures.cs
+++ b/test/Signatures.cs
@@ -1,0 +1,124 @@
+using System.Net.Http;
+using NUnit.Framework;
+using Ovh.Api;
+
+namespace Ovh.Test
+{
+    [TestFixture]
+    public class Signatures
+    {
+        static long currentServerTimestamp = 1566485767;
+
+        [Test]
+        [TestCase("/", "$1$c87db4be631d68b610079e088248dfe8881c40a1")]
+        [TestCase("/me", "$1$b395d13fdb1e1aae1db2be96c6d120677c4d2000")]
+        [TestCase("/auth/time", "$1$3e26ff19629bd612b1e688f1ef61b6446b5c686e")]
+        [TestCase("/mails/accounts?id=5", "$1$0abd51a142538aec522fd4882e178e695b5458c4")]
+        [TestCase("/mails?to=45&from=12", "$1$26b79c495a18b45bb1f197bfe3f262ecb5f21016")]
+        public void generate_signature_for_a_get_call(string target, string expectedSignature)
+        {
+            var sig = Client.GenerateSignature(
+                Constants.APPLICATION_SECRET,
+                Constants.CONSUMER_KEY,
+                currentServerTimestamp,
+                "GET",
+                target);
+
+            Assert.AreEqual(expectedSignature, sig);
+        }
+
+        [Test]
+        [TestCase("/", "$1$71d90b786d8200b46ff2736400ee416d5fe41079")]
+        [TestCase("/me", "$1$0901964347daac6ab470f35286114a0add0ba399")]
+        [TestCase("/auth/time", "$1$a4b70a7521cc6b397d84c9de2c0066f82a2ac277")]
+        [TestCase("/mails/accounts?id=5", "$1$6d2c0ba0ab22629c6739a5f450cc47aeb785ab78")]
+        [TestCase("/mails?to=45&from=12", "$1$7bb0e50be918aa6739ef1a183c7c76e73a79494f")]
+        public void generate_signature_for_a_delete_call(string target, string expectedSignature)
+        {
+            var sig = Client.GenerateSignature(
+                Constants.APPLICATION_SECRET,
+                Constants.CONSUMER_KEY,
+                currentServerTimestamp,
+                "DELETE",
+                target);
+
+            Assert.AreEqual(expectedSignature, sig);
+        }
+
+        [Test]
+        [TestCase("/", "$1$4a09d6cf15fc021ffb73da3c24797b2641cf2424")]
+        [TestCase("/me", "$1$36c9811602d49b74f4374aafc0f1f26ff6724293")]
+        [TestCase("/auth/time", "$1$a0ce8be3ebc95a4168237abaca254bed535601b0")]
+        [TestCase("/mails/accounts?id=5", "$1$ded453bab00328fe1753768db2926cf931a1e0e6")]
+        [TestCase("/mails?to=45&from=12", "$1$62904b4a7be1298f263af4b5a38ea384132906f8")]
+        public void generate_signature_for_a_post_call_without_data(string target, string expectedSignature)
+        {
+            var sig = Client.GenerateSignature(
+                Constants.APPLICATION_SECRET,
+                Constants.CONSUMER_KEY,
+                currentServerTimestamp,
+                "POST",
+                target);
+
+            Assert.AreEqual(expectedSignature, sig);
+        }
+
+        [Test]
+        [TestCase("/", "{\"data\":\"value\"}", "$1$369d08d098480a4769db04bf3f0ce8e7a266ca7e")]
+        [TestCase("/me", "some_data", "$1$6a0e930b55e9c6d8b695084782f567031d5230ed")]
+        [TestCase("/auth/time", "[{\"data\":\"value\"},{\"data-2\":\"value-2\"}]", "$1$7d0a0141e32070c6046890a59afa4f034c08a3f0")]
+        [TestCase("/mails/accounts?id=5", "{\"data\":\"value\"}", "$1$42b3029887864b9191302ccddc7229846b11c353")]
+        [TestCase("/mails?to=45&from=12", "{\"data\":\"value\"}", "$1$e23dcacc5411034a832e05c7fe9f7b2ae5c9578f")]
+        public void generate_signature_for_a_post_call_with_data(string target, string data, string expectedSignature)
+        {
+            var sig = Client.GenerateSignature(
+                Constants.APPLICATION_SECRET,
+                Constants.CONSUMER_KEY,
+                currentServerTimestamp,
+                "POST",
+                target,
+                data);
+
+            Assert.AreEqual(expectedSignature, sig);
+        }
+
+        [Test]
+        [TestCase("/", "$1$c1fac5e97db0830c9bd33bad6181e317c33ae6cd")]
+        [TestCase("/me", "$1$725acf08ac67cf402679b91791cda17eba656b26")]
+        [TestCase("/auth/time", "$1$1857d9e775b2ab963244623ae3f97362a529c5a5")]
+        [TestCase("/mails/accounts?id=5", "$1$72d379b8cb16ff4258e26e9f8c9aacb1d6958c3e")]
+        [TestCase("/mails?to=45&from=12", "$1$1fbaa78566ac80f6c73169f4798fc29cc454dcb1")]
+        public void generate_signature_for_a_put_call_without_data(string target, string expectedSignature)
+        {
+            var sig = Client.GenerateSignature(
+                Constants.APPLICATION_SECRET,
+                Constants.CONSUMER_KEY,
+                currentServerTimestamp,
+                "PUT",
+                target);
+
+            Assert.AreEqual(expectedSignature, sig);
+        }
+
+        [Test]
+        [TestCase("/", "{\"data\":\"value\"}", "$1$ee4b4ac586796b17062397a7a390349306898e51")]
+        [TestCase("/me", "some_data", "$1$386dc87d403f526a1e2a6c75b915a4ecedf0d224")]
+        [TestCase("/auth/time", "[{\"data\":\"value\"},{\"data-2\":\"value-2\"}]", "$1$a991d5bad1a5c8ddfff315668a7c4842b24958ef")]
+        [TestCase("/mails/accounts?id=5", "{\"data\":\"value\"}", "$1$590f78e1c78eec4e163afe36bf7c157d9244b682")]
+        [TestCase("/mails?to=45&from=12", "{\"data\":\"value\"}", "$1$dacdb2f3407325e3fd0e6c8c3b797dca08d4491f")]
+        public void generate_signature_for_a_put_call_with_data(string target, string data, string expectedSignature)
+        {
+            var sig = Client.GenerateSignature(
+                Constants.APPLICATION_SECRET,
+                Constants.CONSUMER_KEY,
+                currentServerTimestamp,
+                "PUT",
+                target,
+                data);
+
+            Assert.AreEqual(expectedSignature, sig);
+        }
+
+    }
+}
+

--- a/test/test.csproj
+++ b/test/test.csproj
@@ -1,17 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
+    <PackageReference Include="FakeItEasy" Version="5.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NUnit" Version="3.8.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\csharp-ovh\csharp-ovh.csproj" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
  - Features:
    - HttpClient can be passed as an argument to the constructor, making
    it possible to reuse an existing one
    - HttpClient instance is static, so all Ovh.Client share the same
    - Obsoletes all sync method, as they do not exist in HttpClient
    - Switches README to [...]Async methods
  - Fixes:
    - Character separator for Batch requests is no longer ignored
    - Timeout is no longer ignored (note: for now, and because
    the HttpClient instance is static, the value given to the first
    Ovh.Client instantiation will be used for all other instances)
  - Testing:
    - Exposes GenerateSignature
    - Exposes a way to mock DateTimeOffset
    - Adds a first round of tests for signature and calls