### PR TITLE
Scope timeout to Ovh.Client, and allow each call method to set a specific one

### DIFF
--- a/csharp-ovh/Client/Client.Delete.cs
+++ b/csharp-ovh/Client/Client.Delete.cs
@@ -36,9 +36,9 @@ namespace Ovh.Api
         /// <param name="target">API method to call</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>Raw API response</returns>
-        public Task<string> DeleteAsync(string target, bool needAuth = true)
+        public Task<string> DeleteAsync(string target, bool needAuth = true, TimeSpan? timeout = null)
         {
-            return CallAsync("DELETE", target, null, needAuth);
+            return CallAsync("DELETE", target, null, needAuth, timeout: timeout);
         }
 
         /// <summary>
@@ -48,9 +48,9 @@ namespace Ovh.Api
         /// <param name="target">API method to call</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>API response deserialized to T by JSON.Net</returns>
-        public Task<T> DeleteAsync<T>(string target, bool needAuth = true)
+        public Task<T> DeleteAsync<T>(string target, bool needAuth = true, TimeSpan? timeout = null)
         {
-            return CallAsync<T>("DELETE", target, null, needAuth);
+            return CallAsync<T>("DELETE", target, null, needAuth, timeout: timeout);
         }
     }
 }

--- a/csharp-ovh/Client/Client.Get.cs
+++ b/csharp-ovh/Client/Client.Get.cs
@@ -72,10 +72,10 @@ namespace Ovh.Api
         /// <param name="kwargs">Arguments to append to URL</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>Raw API response</returns>
-        public Task<string> GetAsync(string target, QueryStringParams kwargs = null, bool needAuth = true)
+        public Task<string> GetAsync(string target, QueryStringParams kwargs = null, bool needAuth = true, TimeSpan? timeout = null)
         {
             target += kwargs?.ToString();
-            return CallAsync("GET", target, null, needAuth);
+            return CallAsync("GET", target, null, needAuth, timeout: timeout);
         }
 
         /// <summary>
@@ -85,10 +85,10 @@ namespace Ovh.Api
         /// <param name="kwargs">Arguments to append to URL</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>Raw API response</returns>
-        public Task<string> GetBatchAsync(string target, QueryStringParams kwargs = null, bool needAuth = true)
+        public Task<string> GetBatchAsync(string target, QueryStringParams kwargs = null, bool needAuth = true, TimeSpan? timeout = null)
         {
             target += kwargs?.ToString();
-            return CallAsync("GET", target, null, needAuth, isBatch: true);
+            return CallAsync("GET", target, null, needAuth, isBatch: true, timeout: timeout);
         }
 
         /// <summary>
@@ -99,10 +99,10 @@ namespace Ovh.Api
         /// <param name="kwargs">Arguments to append to URL</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>API response deserialized to T by JSON.Net</returns>
-        public Task<T> GetAsync<T>(string target, QueryStringParams kwargs = null, bool needAuth = true)
+        public Task<T> GetAsync<T>(string target, QueryStringParams kwargs = null, bool needAuth = true, TimeSpan? timeout = null)
         {
             target += kwargs?.ToString();
-            return CallAsync<T>("GET", target, null, needAuth);
+            return CallAsync<T>("GET", target, null, needAuth, timeout: timeout);
         }
 
         /// <summary>
@@ -113,10 +113,10 @@ namespace Ovh.Api
         /// <param name="kwargs">Arguments to append to URL</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>API response deserialized to List<T> by JSON.Net</returns>
-        public Task<List<T>> GetBatchAsync<T>(string target, QueryStringParams kwargs = null, bool needAuth = true)
+        public Task<List<T>> GetBatchAsync<T>(string target, QueryStringParams kwargs = null, bool needAuth = true, TimeSpan? timeout = null)
         {
             target += kwargs?.ToString();
-            return CallAsync<List<T>>("GET", target, null, needAuth, isBatch: true);
+            return CallAsync<List<T>>("GET", target, null, needAuth, isBatch: true, timeout: timeout);
         }
     }
 }

--- a/csharp-ovh/Client/Client.Post.cs
+++ b/csharp-ovh/Client/Client.Post.cs
@@ -55,9 +55,9 @@ namespace Ovh.Api
         /// <param name="data">Json data to send as body</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>Raw API response</returns>
-        public Task<string> PostAsync(string target, string data, bool needAuth = true)
+        public Task<string> PostAsync(string target, string data, bool needAuth = true, TimeSpan? timeout = null)
         {
-            return CallAsync("POST", target, data, needAuth);
+            return CallAsync("POST", target, data, needAuth, timeout: timeout);
         }
 
         /// <summary>
@@ -68,9 +68,9 @@ namespace Ovh.Api
         /// <param name="data">Json data to send as body</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>API response deserialized to T by JSON.Net</returns>
-        public Task<T> PostAsync<T>(string target, string data, bool needAuth = true)
+        public Task<T> PostAsync<T>(string target, string data, bool needAuth = true, TimeSpan? timeout = null)
         {
-            return CallAsync<T>("POST", target, data, needAuth);
+            return CallAsync<T>("POST", target, data, needAuth, timeout: timeout);
         }
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace Ovh.Api
         /// <param name="data">Json data to send as body</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>API response deserialized to T by JSON.Net with Strongly typed object as input</returns>
-        public Task<T> PostAsync<T, Y>(string target, Y data, bool needAuth = true)
+        public Task<T> PostAsync<T, Y>(string target, Y data, bool needAuth = true, TimeSpan? timeout = null)
             where Y : class
         {
             return CallAsync<T, Y>("POST", target, data, needAuth);

--- a/csharp-ovh/Client/Client.Put.cs
+++ b/csharp-ovh/Client/Client.Put.cs
@@ -55,9 +55,9 @@ namespace Ovh.Api
         /// <param name="data">Json data to send as body</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>Raw API response</returns>
-        public Task<string> PutAsync(string target, string data, bool needAuth = true)
+        public Task<string> PutAsync(string target, string data, bool needAuth = true, TimeSpan? timeout = null)
         {
-            return CallAsync("PUT", target, data, needAuth);
+            return CallAsync("PUT", target, data, needAuth, timeout: timeout);
         }
 
         /// <summary>
@@ -68,9 +68,9 @@ namespace Ovh.Api
         /// <param name="data">Json data to send as body</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>API response deserialized to T by JSON.Net</returns>
-        public Task<T> PutAsync<T>(string target, string data, bool needAuth = true)
+        public Task<T> PutAsync<T>(string target, string data, bool needAuth = true, TimeSpan? timeout = null)
         {
-            return CallAsync<T>("PUT", target, data, needAuth);
+            return CallAsync<T>("PUT", target, data, needAuth, timeout: timeout);
         }
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace Ovh.Api
         /// <param name="data">Json data to send as body</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <returns>API response deserialized to T by JSON.Net with Strongly typed object as input</returns>
-        public Task<T> PutAsync<T, Y>(string target, Y data, bool needAuth = true)
+        public Task<T> PutAsync<T, Y>(string target, Y data, bool needAuth = true, TimeSpan? timeout = null)
             where Y : class
         {
             return CallAsync<T, Y>("PUT", target, data, needAuth);

--- a/test/ClientFactory.cs
+++ b/test/ClientFactory.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net.Http;
 using Ovh.Api;
 
@@ -9,11 +10,11 @@ namespace Ovh.Test
 
         public static Client GetClient(FakeHttpMessageHandler handler, bool withConsumerKey = true)
         {
-            if(withConsumerKey)
+            if (withConsumerKey)
             {
-                return new Client(new HttpClient(handler), Constants.ENDPOINT, Constants.APPLICATION_KEY, Constants.APPLICATION_SECRET, Constants.CONSUMER_KEY);
+                return new Client(Constants.ENDPOINT, Constants.APPLICATION_KEY, Constants.APPLICATION_SECRET, Constants.CONSUMER_KEY, httpClient: new HttpClient(handler));
             }
-            return new Client(new HttpClient(handler), Constants.ENDPOINT, Constants.APPLICATION_KEY, Constants.APPLICATION_SECRET);
+            return new Client(Constants.ENDPOINT, Constants.APPLICATION_KEY, Constants.APPLICATION_SECRET, httpClient: new HttpClient(handler));
         }
 
     }

--- a/test/ClientWithManualParams.cs
+++ b/test/ClientWithManualParams.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using Ovh.Api;
 using Ovh.Api.Exceptions;
+using System;
 
 namespace Ovh.Test
 {
@@ -25,7 +26,7 @@ namespace Ovh.Test
         {
             Client client =
                 new Client("ovh-eu", "applicationKey", "secretKey",
-                    "consumerKey", 120);
+                    "consumerKey", TimeSpan.FromSeconds(120));
             Assert.AreEqual(client.Endpoint, "https://eu.api.ovh.com/1.0/");
         }
 

--- a/test/GetRequests.cs
+++ b/test/GetRequests.cs
@@ -38,7 +38,7 @@ namespace Ovh.Test
             MockAuthTimeCallWithFakeItEasy(testHandler);
 
             var httpClient = new HttpClient(testHandler);
-            var c = new Client(httpClient, "ovh-eu").AsTestable(timeProvider);
+            var c = new Client("ovh-eu", httpClient: httpClient).AsTestable(timeProvider);
 
             Assert.AreEqual(2, c.TimeDelta);
         }
@@ -74,7 +74,7 @@ namespace Ovh.Test
         }
 
         [Test]
-        public async Task ET_me_as_T()
+        public async Task GET_me_as_T()
         {
             var fake = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
             MockAuthTimeCallWithFakeItEasy(fake);
@@ -95,7 +95,7 @@ namespace Ovh.Test
         }
 
         [Test]
-        public async Task ET_with_filter_generates_correct_signature()
+        public async Task GET_with_filter_generates_correct_signature()
         {
             var fake = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
             MockAuthTimeCallWithFakeItEasy(fake);


### PR DESCRIPTION
Fixes #31 
Fixes #32 

A timeout can be passed to the constructor of Ovh.Client, and will only stick to it. Under the hood, a cancellation token is prepared with it for each call. Alternatively, a specific timeout can be passed on a case-by-case basis on each async method (sync method left untouched as they are obsolete).

One constructor could be removed on Ovh.Client (both where almost the same at the end).

Just a word on the tests: currently, I can't find any solution to play with the timeout without requiring real HTTP calls. Since we are mocking the HttpMessageHandler, the CancellationToken is completely ignored. I'm open to any idea !