### PR TITLE
Add ability to create Ovh.Client with custom conf file

### DIFF
--- a/csharp-ovh/Client/Client.cs
+++ b/csharp-ovh/Client/Client.cs
@@ -138,9 +138,10 @@ namespace Ovh.Api
         }
 
         private void LoadConfiguration(string endpoint, string applicationKey,
-            string applicationSecret, string consumerKey, char parameterSeparator)
+            string applicationSecret, string consumerKey, char parameterSeparator, 
+            string confName = ".ovh.conf")
         {
-            ConfigurationManager = new ConfigurationManager();
+            ConfigurationManager = new ConfigurationManager(confName);
 
             try
             {
@@ -225,10 +226,10 @@ namespace Ovh.Api
         /// <param name="timeout">Connection timeout for each request</param>
         /// <param name="parameterSeparator">Separator that should be used when sending Batch Requests</param>
         public Client(string endpoint = null, string applicationKey = null,
-            string applicationSecret = null, string consumerKey = null,
+            string applicationSecret = null, string consumerKey = null, string confName = ".ovh.conf",
             int timeout = _defaultTimeout, char parameterSeparator = ',') : this()
         {
-            LoadConfiguration(endpoint, applicationKey, applicationSecret, consumerKey, parameterSeparator);
+            LoadConfiguration(endpoint, applicationKey, applicationSecret, consumerKey, parameterSeparator, confName);
             Timeout = timeout;
             if (_httpClient == null)
             {

--- a/csharp-ovh/Client/Client.cs
+++ b/csharp-ovh/Client/Client.cs
@@ -139,9 +139,9 @@ namespace Ovh.Api
 
         private void LoadConfiguration(string endpoint, string applicationKey,
             string applicationSecret, string consumerKey, char parameterSeparator, 
-            string confName = ".ovh.conf")
+            string confFileName = ".ovh.conf")
         {
-            ConfigurationManager = new ConfigurationManager(confName);
+            ConfigurationManager = new ConfigurationManager(confFileName);
 
             try
             {
@@ -226,10 +226,10 @@ namespace Ovh.Api
         /// <param name="timeout">Connection timeout for each request</param>
         /// <param name="parameterSeparator">Separator that should be used when sending Batch Requests</param>
         public Client(string endpoint = null, string applicationKey = null,
-            string applicationSecret = null, string consumerKey = null, string confName = ".ovh.conf",
+            string applicationSecret = null, string consumerKey = null, string confFileName = ".ovh.conf",
             int timeout = _defaultTimeout, char parameterSeparator = ',') : this()
         {
-            LoadConfiguration(endpoint, applicationKey, applicationSecret, consumerKey, parameterSeparator, confName);
+            LoadConfiguration(endpoint, applicationKey, applicationSecret, consumerKey, parameterSeparator, confFileName);
             Timeout = timeout;
             if (_httpClient == null)
             {

--- a/csharp-ovh/Config.cs
+++ b/csharp-ovh/Config.cs
@@ -73,7 +73,6 @@ namespace Ovh.Api
             AppDomain.CurrentDomain.BaseDirectory
         };
 
-        private const string _confName = ".ovh.conf";
         /// <summary>
         /// INI data from the configuration file
         /// </summary>
@@ -82,9 +81,9 @@ namespace Ovh.Api
         /// <summary>
         /// Create a config parser and load config from environment.
         /// </summary>
-        public ConfigurationManager()
+        public ConfigurationManager(string confName)
         {
-            string chosenPath = _configPaths.LastOrDefault(p => File.Exists(Path.Combine(p, _confName)));
+            string chosenPath = _configPaths.LastOrDefault(p => File.Exists(Path.Combine(p, confName)));
             if (chosenPath == null)
             {
                 Config = new ConfigurationBuilder().Build();
@@ -93,7 +92,7 @@ namespace Ovh.Api
             {
                 var provider = new PhysicalFileProvider(chosenPath, ExclusionFilters.System);
                 Config = new ConfigurationBuilder()
-                    .AddIniFile(provider, _confName, false, false)
+                    .AddIniFile(provider, confName, false, false)
                     .Build();
             }
         }

--- a/csharp-ovh/Config.cs
+++ b/csharp-ovh/Config.cs
@@ -81,9 +81,9 @@ namespace Ovh.Api
         /// <summary>
         /// Create a config parser and load config from environment.
         /// </summary>
-        public ConfigurationManager(string confName)
+        public ConfigurationManager(string confFileName)
         {
-            string chosenPath = _configPaths.LastOrDefault(p => File.Exists(Path.Combine(p, confName)));
+            string chosenPath = _configPaths.LastOrDefault(p => File.Exists(Path.Combine(p, confFileName)));
             if (chosenPath == null)
             {
                 Config = new ConfigurationBuilder().Build();
@@ -92,7 +92,7 @@ namespace Ovh.Api
             {
                 var provider = new PhysicalFileProvider(chosenPath, ExclusionFilters.System);
                 Config = new ConfigurationBuilder()
-                    .AddIniFile(provider, confName, false, false)
+                    .AddIniFile(provider, confFileName, false, false)
                     .Build();
             }
         }

--- a/test/ClientWithConfigFile.cs
+++ b/test/ClientWithConfigFile.cs
@@ -34,6 +34,13 @@ namespace Ovh.Test
                 "endpoint=ovh-eu");
         }
 
+        public void CreateConfigFileWithSpecificFileName(string confFileName)
+        {
+            File.WriteAllText(confFileName,
+                "[default]" + Environment.NewLine +
+                "endpoint=ovh-eu");
+        }
+
         public void CreateConfigFileWithAllValues()
         {
             File.WriteAllText(".ovh.conf",
@@ -59,6 +66,14 @@ namespace Ovh.Test
         {
             CreateConfigFileWithEndpointOnly();
             Client client = new Client();
+            Assert.AreEqual(client.Endpoint, "https://eu.api.ovh.com/1.0/");
+        }
+
+        [Test]
+        public void ValidConfigFileWithSpecificFileName()
+        {
+            CreateConfigFileWithSpecificFileName("some-specific-file.conf");
+            Client client = new Client(confFileName: "some-specific-file.conf");
             Assert.AreEqual(client.Endpoint, "https://eu.api.ovh.com/1.0/");
         }
 

--- a/test/ClientWithConfigFile.cs
+++ b/test/ClientWithConfigFile.cs
@@ -10,14 +10,13 @@ namespace Ovh.Test
     public class ClientWithConfigFile
     {
         public const string OvhConfigFile = ".ovh.conf";
+        public const string CustomConfigFile = "some-specific-file.conf";
 
         [TearDown]
         public void RemoveConfigFile()
         {
-            if (File.Exists(OvhConfigFile))
-            {
-                File.Delete(OvhConfigFile);
-            }
+            File.Delete(OvhConfigFile);
+            File.Delete(CustomConfigFile);
         }
 
         public void CreateInvalidConfigFile()
@@ -72,8 +71,8 @@ namespace Ovh.Test
         [Test]
         public void ValidConfigFileWithSpecificFileName()
         {
-            CreateConfigFileWithSpecificFileName("some-specific-file.conf");
-            Client client = new Client(confFileName: "some-specific-file.conf");
+            CreateConfigFileWithSpecificFileName(CustomConfigFile);
+            Client client = new Client(confFileName: CustomConfigFile);
             Assert.AreEqual(client.Endpoint, "https://eu.api.ovh.com/1.0/");
         }
 

--- a/test/ClientWithManualParams.cs
+++ b/test/ClientWithManualParams.cs
@@ -25,7 +25,7 @@ namespace Ovh.Test
         {
             Client client =
                 new Client("ovh-eu", "applicationKey", "secretKey",
-                    "consumerKey", 120);
+                    "consumerKey", timeout: 120);
             Assert.AreEqual(client.Endpoint, "https://eu.api.ovh.com/1.0/");
         }
 


### PR DESCRIPTION
Configuration filename can now be passed in Ovh.Client constructor.
Default value is still `.ovh.conf`.