### PR TITLE
Remove useless Y param for POST and PUT

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -307,7 +307,7 @@ This example assumes an existing Configuration_ with valid ``application_key``,
                     var details = await client.GetAsync<PartialDedicatedServer>(serverUrl);
                     if (details.datacenter == "sbg1")
                     {
-                        await client.PutAsync(serverUrl + "/burst", "{\"status\":\"active\"}");
+                        await client.PutStringAsync(serverUrl + "/burst", "{\"status\":\"active\"}");
                         Console.WriteLine("Burst enabled on server " + serverId);
                     }
                 }

--- a/README.rst
+++ b/README.rst
@@ -211,7 +211,7 @@ OVH to an arbitrary destination e-mail using API call
 
                 client.PostAsync(
                     String.Format("/email/domain/{0}/redirection", domain),
-                    JsonConvert.SerializeObject(payload)
+                    payload
                 ).Wait();
 
                 Console.WriteLine(

--- a/csharp-ovh/Client/Client.Post.cs
+++ b/csharp-ovh/Client/Client.Post.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace Ovh.Api
 {
@@ -9,43 +10,56 @@ namespace Ovh.Api
         /// Issues an async POST call
         /// </summary>
         /// <param name="target">API method to call</param>
-        /// <param name="data">Json data to send as body</param>
+        /// <param name="json">Json string to send as body</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <param name="timeout">If specified, overrides default <see cref="Client"/>'s timeout with a custom one</param>
         /// <returns>Raw API response</returns>
-        public Task<string> PostAsync(string target, string data, bool needAuth = true, TimeSpan? timeout = null)
+        public Task<string> PostStringAsync(string target, string json, bool needAuth = true, TimeSpan? timeout = null)
         {
-            return CallAsync("POST", target, data, needAuth, timeout: timeout);
+            return CallAsync("POST", target, json, needAuth, timeout: timeout);
         }
 
         /// <summary>
         /// Issues an async POST call
         /// </summary>
+        /// <param name="target">API method to call</param>
+        /// <param name="data">Object to be serialized and sent as a json body</param>
+        /// <param name="needAuth">If true, send authentication headers</param>
+        /// <param name="timeout">If specified, overrides default <see cref="Client"/>'s timeout with a custom one</param>
+        /// <returns>Raw API response</returns>
+        public Task<string> PostAsync(string target, object data = null, bool needAuth = true, TimeSpan? timeout = null)
+        {
+            string json = data is null ? null : JsonConvert.SerializeObject(data);
+            return CallAsync("POST", target, json, needAuth, timeout: timeout);
+        }
+
+        /// <summary>
+        /// Issues an async POST call.
+        /// </summary>
         /// <typeparam name="T">Expected return type</typeparam>
         /// <param name="target">API method to call</param>
-        /// <param name="data">Json data to send as body</param>
+        /// <param name="json">Json string to send as body</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <param name="timeout">If specified, overrides default <see cref="Client"/>'s timeout with a custom one</param>
         /// <returns>API response deserialized to T by JSON.Net</returns>
-        public Task<T> PostAsync<T>(string target, string data, bool needAuth = true, TimeSpan? timeout = null)
+        public Task<T> PostStringAsync<T>(string target, string json, bool needAuth = true, TimeSpan? timeout = null)
         {
-            return CallAsync<T>("POST", target, data, needAuth, timeout: timeout);
+            return CallAsync<T>("POST", target, json, needAuth, timeout: timeout);
         }
 
         /// <summary>
         /// Issues an aync POST call
         /// </summary>
         /// <typeparam name="T">Expected return type</typeparam>
-        /// <typeparam name="Y">Input type</typeparam>
         /// <param name="target">API method to call</param>
-        /// <param name="data">Json data to send as body</param>
+        /// <param name="data">Object to be serialized and sent as a json body</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <param name="timeout">If specified, overrides default <see cref="Client"/>'s timeout with a custom one</param>
         /// <returns>API response deserialized to T by JSON.Net with Strongly typed object as input</returns>
-        public Task<T> PostAsync<T>(string target, object data, bool needAuth = true, TimeSpan? timeout = null)
+        public Task<T> PostAsync<T>(string target, object data = null, bool needAuth = true, TimeSpan? timeout = null)
         {
-            return CallAsync<T>("POST", target, data, needAuth);
+            string json = data is null ? null : JsonConvert.SerializeObject(data);
+            return CallAsync<T>("POST", target, json, needAuth, timeout: timeout);
         }
-
     }
 }

--- a/csharp-ovh/Client/Client.Post.cs
+++ b/csharp-ovh/Client/Client.Post.cs
@@ -42,10 +42,9 @@ namespace Ovh.Api
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <param name="timeout">If specified, overrides default <see cref="Client"/>'s timeout with a custom one</param>
         /// <returns>API response deserialized to T by JSON.Net with Strongly typed object as input</returns>
-        public Task<T> PostAsync<T, Y>(string target, Y data, bool needAuth = true, TimeSpan? timeout = null)
-            where Y : class
+        public Task<T> PostAsync<T>(string target, object data, bool needAuth = true, TimeSpan? timeout = null)
         {
-            return CallAsync<T, Y>("POST", target, data, needAuth);
+            return CallAsync<T>("POST", target, data, needAuth);
         }
 
     }

--- a/csharp-ovh/Client/Client.Put.cs
+++ b/csharp-ovh/Client/Client.Put.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace Ovh.Api
 {
@@ -9,13 +10,27 @@ namespace Ovh.Api
         /// Issues an async PUT call
         /// </summary>
         /// <param name="target">API method to call</param>
-        /// <param name="data">Json data to send as body</param>
+        /// <param name="data">Json string to send as body</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <param name="timeout">If specified, overrides default <see cref="Client"/>'s timeout with a custom one</param>
         /// <returns>Raw API response</returns>
-        public Task<string> PutAsync(string target, string data, bool needAuth = true, TimeSpan? timeout = null)
+        public Task<string> PutStringAsync(string target, string json, bool needAuth = true, TimeSpan? timeout = null)
         {
-            return CallAsync("PUT", target, data, needAuth, timeout: timeout);
+            return CallAsync("PUT", target, json, needAuth, timeout: timeout);
+        }
+
+        /// <summary>
+        /// Issues an async PUT call
+        /// </summary>
+        /// <param name="target">API method to call</param>
+        /// <param name="data">Object to be serialized and sent as a json body</param>
+        /// <param name="needAuth">If true, send authentication headers</param>
+        /// <param name="timeout">If specified, overrides default <see cref="Client"/>'s timeout with a custom one</param>
+        /// <returns>Raw API response</returns>
+        public Task<string> PutAsync(string target, object data = null, bool needAuth = true, TimeSpan? timeout = null)
+        {
+            string json = data is null ? null : JsonConvert.SerializeObject(data);
+            return CallAsync("PUT", target, json, needAuth, timeout: timeout);
         }
 
         /// <summary>
@@ -23,28 +38,28 @@ namespace Ovh.Api
         /// </summary>
         /// <typeparam name="T">Expected return type</typeparam>
         /// <param name="target">API method to call</param>
-        /// <param name="data">Json data to send as body</param>
+        /// <param name="data">Json string to send as body</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <param name="timeout">If specified, overrides default <see cref="Client"/>'s timeout with a custom one</param>
         /// <returns>API response deserialized to T by JSON.Net</returns>
-        public Task<T> PutAsync<T>(string target, string data, bool needAuth = true, TimeSpan? timeout = null)
+        public Task<T> PutStringAsync<T>(string target, string json, bool needAuth = true, TimeSpan? timeout = null)
         {
-            return CallAsync<T>("PUT", target, data, needAuth, timeout: timeout);
+            return CallAsync<T>("PUT", target, json, needAuth, timeout: timeout);
         }
 
         /// <summary>
         /// Issues an async PUT call
         /// </summary>
         /// <typeparam name="T">Expected return type</typeparam>
-        /// <typeparam name="Y">Input type</typeparam>
         /// <param name="target">API method to call</param>
-        /// <param name="data">Json data to send as body</param>
+        /// <param name="data">Object to be serialized and sent as a json body</param>
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <param name="timeout">If specified, overrides default <see cref="Client"/>'s timeout with a custom one</param>
         /// <returns>API response deserialized to T by JSON.Net with Strongly typed object as input</returns>
-        public Task<T> PutAsync<T>(string target, object data, bool needAuth = true, TimeSpan? timeout = null)
+        public Task<T> PutAsync<T>(string target, object data = null, bool needAuth = true, TimeSpan? timeout = null)
         {
-            return CallAsync<T>("PUT", target, data, needAuth);
+            string json = data is null ? null : JsonConvert.SerializeObject(data);
+            return CallAsync<T>("PUT", target, json, needAuth, timeout: timeout);
         }
     }
 

--- a/csharp-ovh/Client/Client.Put.cs
+++ b/csharp-ovh/Client/Client.Put.cs
@@ -42,10 +42,9 @@ namespace Ovh.Api
         /// <param name="needAuth">If true, send authentication headers</param>
         /// <param name="timeout">If specified, overrides default <see cref="Client"/>'s timeout with a custom one</param>
         /// <returns>API response deserialized to T by JSON.Net with Strongly typed object as input</returns>
-        public Task<T> PutAsync<T, Y>(string target, Y data, bool needAuth = true, TimeSpan? timeout = null)
-            where Y : class
+        public Task<T> PutAsync<T>(string target, object data, bool needAuth = true, TimeSpan? timeout = null)
         {
-            return CallAsync<T, Y>("PUT", target, data, needAuth);
+            return CallAsync<T>("PUT", target, data, needAuth);
         }
     }
 

--- a/csharp-ovh/Client/Client.cs
+++ b/csharp-ovh/Client/Client.cs
@@ -228,7 +228,7 @@ namespace Ovh.Api
         /// <returns>A result with the confirmation URL returned by the API</returns>
         public async Task<CredentialRequestResult> RequestConsumerKeyAsync(CredentialRequest credentialRequest)
         {
-            return await PostAsync<CredentialRequestResult, CredentialRequest>("/auth/credential", credentialRequest, false);
+            return await PostAsync<CredentialRequestResult>("/auth/credential", credentialRequest, false);
         }
 
         /// <summary>
@@ -362,8 +362,7 @@ namespace Ovh.Api
             return JsonConvert.DeserializeObject<T>(response);
         }
 
-        private Task<T> CallAsync<T, Y>(string method, string path, Y data = null, bool needAuth = true)
-            where Y : class
+        private Task<T> CallAsync<T>(string method, string path, object data = null, bool needAuth = true)
         {
             return CallAsync<T>(method, path, JsonConvert.SerializeObject(data), needAuth);
         }

--- a/csharp-ovh/Client/Client.cs
+++ b/csharp-ovh/Client/Client.cs
@@ -362,11 +362,6 @@ namespace Ovh.Api
             return JsonConvert.DeserializeObject<T>(response);
         }
 
-        private Task<T> CallAsync<T>(string method, string path, object data = null, bool needAuth = true)
-        {
-            return CallAsync<T>(method, path, JsonConvert.SerializeObject(data), needAuth);
-        }
-
         #endregion
 
         private async Task<ApiException> ExtractExceptionFromHttpResponse(HttpResponseMessage response)

--- a/test/FakeHttpMessageHandler.cs
+++ b/test/FakeHttpMessageHandler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Ovh.Test
@@ -14,9 +15,15 @@ namespace Ovh.Test
             throw new NotImplementedException("Now we can setup this method with our mocking framework");
         }
 
-        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            return await Task.Factory.StartNew(() => Send(request), cancellationToken);
+            return await Task.Factory.StartNew(() =>
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var response = Send(request);
+                cancellationToken.ThrowIfCancellationRequested();
+                return response;
+            }, cancellationToken);
         }
     }
 }

--- a/test/GetRequests.cs
+++ b/test/GetRequests.cs
@@ -86,7 +86,7 @@ namespace Ovh.Test
                 .Invokes(() => Thread.Sleep(1000))
                 .Returns(Responses.Get.me_message);
 
-            var c = ClientFactory.GetClient(fake, timeout: TimeSpan.FromMilliseconds(5));
+            var c = ClientFactory.GetClient(fake, timeout: TimeSpan.Zero);
             Assert.ThrowsAsync<TaskCanceledException>(async () => await c.GetAsync("/me"));
         }
 

--- a/test/GetRequests.cs
+++ b/test/GetRequests.cs
@@ -87,7 +87,7 @@ namespace Ovh.Test
                 .Returns(Responses.Get.me_message);
 
             var c = ClientFactory.GetClient(fake, timeout: TimeSpan.Zero);
-            Assert.ThrowsAsync<TaskCanceledException>(async () => await c.GetAsync("/me"));
+            Assert.ThrowsAsync<TaskCanceledException>(() => c.GetAsync("/me"));
         }
 
         [Test]

--- a/test/GetRequests.cs
+++ b/test/GetRequests.cs
@@ -86,7 +86,7 @@ namespace Ovh.Test
                 .Invokes(() => Thread.Sleep(1000))
                 .Returns(Responses.Get.me_message);
 
-            var c = ClientFactory.GetClient(fake, timeout: TimeSpan.Zero);
+            var c = ClientFactory.GetClient(fake, timeout: TimeSpan.FromMilliseconds(5));
             Assert.ThrowsAsync<TaskCanceledException>(async () => await c.GetAsync("/me"));
         }
 

--- a/test/PostRequests.cs
+++ b/test/PostRequests.cs
@@ -132,7 +132,7 @@ namespace Ovh.Test
             var lol = JsonConvert.SerializeObject(dummyContact);
 
             var c = ClientFactory.GetClient(testHandler).AsTestable(timeProvider);
-            var result = await c.PostAsync<Contact, Contact>("/me/contact", dummyContact);
+            var result = await c.PostAsync<Contact>("/me/contact", dummyContact);
 
             //Ensure that the call went through correctly
             Assert.AreEqual(123456, result.id);

--- a/test/PutRequests.cs
+++ b/test/PutRequests.cs
@@ -88,7 +88,7 @@ namespace Ovh.Test
             var patch = new {address = new {line1 = "Hey there"} };
 
             var c = ClientFactory.GetClient(testHandler).AsTestable(timeProvider);
-            var result = await c.PutAsync<Contact, object>("/me/contact", patch);
+            var result = await c.PutAsync<Contact>("/me/contact", patch);
             Assert.AreEqual("00000", result.address.zip);
 
             var contactCall = Fake.GetCalls(testHandler).Where(call =>

--- a/test/PutRequests.cs
+++ b/test/PutRequests.cs
@@ -32,7 +32,37 @@ namespace Ovh.Test
         }
 
         [Test]
-        public async Task UT_with_data_as_string_and_result_as_string()
+        public async Task PUT_with_raw_string_data_and_string_result()
+        {
+            var testHandler = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
+            MockAuthTimeCallWithFakeItEasy(testHandler);
+            A.CallTo(() =>
+                testHandler.Send(A<HttpRequestMessage>.That.Matches(
+                    r => r.RequestUri.ToString().Contains("/me/contact"))))
+                .Returns(Responses.Put.me_contact_message);
+
+            var c = ClientFactory.GetClient(testHandler).AsTestable(timeProvider);
+            var result = await c.PutStringAsync("/me/contact", "Fake content");
+            Assert.AreEqual(Responses.Put.me_contact_content, result);
+
+            var contactCall = Fake.GetCalls(testHandler).Where(call =>
+                call.Method.Name == "Send" &&
+                call.GetArgument<HttpRequestMessage>("request").RequestUri.ToString().Contains("/me/contact")).First();
+
+            var requestMessage = contactCall.GetArgument<HttpRequestMessage>("request");
+            var headers = requestMessage.Headers;
+            Assert.Multiple(() => {
+                Assert.AreEqual(HttpMethod.Put, requestMessage.Method);
+                Assert.AreEqual(Constants.APPLICATION_KEY, headers.GetValues(Client.OVH_APP_HEADER).First());
+                Assert.AreEqual(Constants.CONSUMER_KEY, headers.GetValues(Client.OVH_CONSUMER_HEADER).First());
+                Assert.AreEqual(currentServerTimestamp.ToString(), headers.GetValues(Client.OVH_TIME_HEADER).First());
+                Assert.AreEqual("$1$5e81842c0f0c806fd703de084d80192a59bc0f8a", headers.GetValues(Client.OVH_SIGNATURE_HEADER).First());
+            });
+        }
+
+
+        [Test]
+        public async Task PUT_with_string_to_be_serialized_data_and_string_result()
         {
             var testHandler = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
             MockAuthTimeCallWithFakeItEasy(testHandler);
@@ -56,12 +86,12 @@ namespace Ovh.Test
                 Assert.AreEqual(Constants.APPLICATION_KEY, headers.GetValues(Client.OVH_APP_HEADER).First());
                 Assert.AreEqual(Constants.CONSUMER_KEY, headers.GetValues(Client.OVH_CONSUMER_HEADER).First());
                 Assert.AreEqual(currentServerTimestamp.ToString(), headers.GetValues(Client.OVH_TIME_HEADER).First());
-                Assert.AreEqual("$1$5e81842c0f0c806fd703de084d80192a59bc0f8a", headers.GetValues(Client.OVH_SIGNATURE_HEADER).First());
+                Assert.AreEqual("$1$ec5195342ad1c81073c2eb3f3d83dd20942c4408", headers.GetValues(Client.OVH_SIGNATURE_HEADER).First());
             });
         }
 
         [Test]
-        public async Task UT_with_data_as_string_and_result_as_T()
+        public async Task PUT_with_raw_string_data_and_T_result()
         {
             var testHandler = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
             MockAuthTimeCallWithFakeItEasy(testHandler);
@@ -76,7 +106,58 @@ namespace Ovh.Test
         }
 
         [Test]
-        public async Task UT_with_data_as_T_and_result_as_T()
+        public async Task PUT_with_no_data_and_string_result()
+        {
+            var testHandler = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
+            MockAuthTimeCallWithFakeItEasy(testHandler);
+            A.CallTo(() =>
+                testHandler.Send(A<HttpRequestMessage>.That.Matches(
+                    r => r.RequestUri.ToString().Contains("/me/contact"))))
+                .Returns(Responses.Put.me_contact_message);
+
+            var patch = new {address = new {line1 = "Hey there"} };
+
+            var c = ClientFactory.GetClient(testHandler).AsTestable(timeProvider);
+            var result = await c.PutAsync("/me/contact");
+            Assert.AreEqual(Responses.Put.me_contact_content, result);
+
+            var contactCall = Fake.GetCalls(testHandler).Where(call =>
+                call.Method.Name == "Send" &&
+                call.GetArgument<HttpRequestMessage>("request").RequestUri.ToString().Contains("/me/contact")).First();
+
+            var requestMessage = contactCall.GetArgument<HttpRequestMessage>("request");
+            var headers = requestMessage.Headers;
+            Assert.AreEqual("$1$5595b180f954de130f8da7a5a4b55adc3d27556f", headers.GetValues(Client.OVH_SIGNATURE_HEADER).First());
+        }
+
+
+        [Test]
+        public async Task PUT_with_no_data_and_T_result()
+        {
+            var testHandler = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
+            MockAuthTimeCallWithFakeItEasy(testHandler);
+            A.CallTo(() =>
+                testHandler.Send(A<HttpRequestMessage>.That.Matches(
+                    r => r.RequestUri.ToString().Contains("/me/contact"))))
+                .Returns(Responses.Put.me_contact_message);
+
+            var patch = new {address = new {line1 = "Hey there"} };
+
+            var c = ClientFactory.GetClient(testHandler).AsTestable(timeProvider);
+            var result = await c.PutAsync<Contact>("/me/contact");
+            Assert.AreEqual("00000", result.address.zip);
+
+            var contactCall = Fake.GetCalls(testHandler).Where(call =>
+                call.Method.Name == "Send" &&
+                call.GetArgument<HttpRequestMessage>("request").RequestUri.ToString().Contains("/me/contact")).First();
+
+            var requestMessage = contactCall.GetArgument<HttpRequestMessage>("request");
+            var headers = requestMessage.Headers;
+            Assert.AreEqual("$1$5595b180f954de130f8da7a5a4b55adc3d27556f", headers.GetValues(Client.OVH_SIGNATURE_HEADER).First());
+        }
+
+        [Test]
+        public async Task PUT_with_T_data_and_T_result()
         {
             var testHandler = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
             MockAuthTimeCallWithFakeItEasy(testHandler);


### PR DESCRIPTION
Fixes #33 

While this seemed like a better idea to have type checking instead of
plain `object`, in reality it is just an added pain that gives no
benefit as the only thing done here is serializing with json.NET which
works with `object` itself anyway.

Signed-off-by: Luke Marlin <luke.marlin@viacesi.fr>