### PR TITLE
Fix #53 Error caused by wrong uri

### DIFF
--- a/csharp-ovh/Client/Client.cs
+++ b/csharp-ovh/Client/Client.cs
@@ -317,11 +317,6 @@ namespace Ovh.Api
         /// <exception cref="InvalidResponseException">when API response could not be decoded</exception>
         private async Task<string> CallAsync(string method, string path, string data = null, bool needAuth = true, bool isBatch = false, TimeSpan? timeout = null)
         {
-            if (path.StartsWith("/"))
-            {
-                path = path.Substring(1);
-            }
-
             HttpResponseMessage response = null;
 
             try


### PR DESCRIPTION
Removing the leading slash causes wrong uris like `https://api.us.ovhcloud.com/1.0auth/time` instead of `https://api.us.ovhcloud.com/1.0/auth/time`