### PR TITLE
Update Client.cs

### DIFF
--- a/csharp-ovh/Client/Client.cs
+++ b/csharp-ovh/Client/Client.cs
@@ -363,8 +363,7 @@ namespace Ovh.Api
             }
             if (response.StatusCode == HttpStatusCode.NoContent)
             {
-                string successMessage = "Success ; Response Status: No Content:204";
-                return successMessage;
+                return "Success ; Response Status: No Content:204";
             }
                 
             throw await ExtractExceptionFromHttpResponse(response).ConfigureAwait(false);

--- a/csharp-ovh/Client/Client.cs
+++ b/csharp-ovh/Client/Client.cs
@@ -361,7 +361,12 @@ namespace Ovh.Api
             {
                 return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             }
-
+            if (response.StatusCode == HttpStatusCode.NoContent)
+            {
+                string successMessage = "Success ; Response Status: No Content:204";
+                return successMessage;
+            }
+                
             throw await ExtractExceptionFromHttpResponse(response).ConfigureAwait(false);
         }
 

--- a/test/PutRequests.cs
+++ b/test/PutRequests.cs
@@ -180,5 +180,28 @@ namespace Ovh.Test
             var headers = requestMessage.Headers;
             Assert.AreEqual("$1$747cdaf92e412ea434a387e6ff7b20150ee1172f", headers.GetValues(Client.OVH_SIGNATURE_HEADER).First());
         }
+
+        [Test]
+        public async Task PUT_with_no_content_result()
+        {
+            var testHandler = A.Fake<FakeHttpMessageHandler>(a => a.CallsBaseMethods());
+            MockAuthTimeCallWithFakeItEasy(testHandler);
+            A.CallTo(() => 
+                    testHandler.Send(A<HttpRequestMessage>.That.Matches(
+                        r => r.RequestUri.ToString().Contains("/me/contact"))))
+                .Returns(Responses.PutWith204Response.response_204_message);
+
+            var c = ClientFactory.GetClient(testHandler).AsTestable(timeProvider);
+            var result = await c.PutAsync("/me/contact");
+            Assert.AreEqual(Responses.PutWith204Response.success_204_response, result);
+
+            var contactCall = Fake.GetCalls(testHandler).Where(call =>
+                call.Method.Name == "Send" &&
+                call.GetArgument<HttpRequestMessage>("request").RequestUri.ToString().Contains("/me/contact")).First();
+
+            var requestMessage = contactCall.GetArgument<HttpRequestMessage>("request");
+            var headers = requestMessage.Headers;
+            Assert.AreEqual("$1$5595b180f954de130f8da7a5a4b55adc3d27556f", headers.GetValues(Client.OVH_SIGNATURE_HEADER).First());
+        }
     }
 }

--- a/test/Responses/PutResponses.cs
+++ b/test/Responses/PutResponses.cs
@@ -9,4 +9,10 @@ namespace Ovh.Test.Responses
         public static readonly HttpResponseMessage me_contact_message =
             HttpResponseMessageFactory.Create(me_contact_content, HttpStatusCode.OK);
     }
+    public static class PutWith204Response
+    {
+        public static readonly string success_204_response = "Success ; Response Status: No Content:204";
+        public static readonly HttpResponseMessage response_204_message =
+            HttpResponseMessageFactory.Create(success_204_response, HttpStatusCode.NoContent);
+    }
 }


### PR DESCRIPTION
Some routes (at the very least : `/cloud/project/{serviceName}/kube/{kubeId}/nodepool/{nodePoolId}`) returns the http status code 204.  

Currently, this creates a null exception, as it isn't HttpStatusCode.OK and there isn't an Exception to extract.

Fixes : #63 
> Signed-off-by: Francis Lalonde <[xargath@hotmail.com](mailto:xargath@hotmail.com)>